### PR TITLE
Enable glowing for all entity types

### DIFF
--- a/implementation_1_19_4/src/main/java/de/oliver/fancynpcs/v1_19_4/Npc_1_19_4.java
+++ b/implementation_1_19_4/src/main/java/de/oliver/fancynpcs/v1_19_4/Npc_1_19_4.java
@@ -169,12 +169,11 @@ public class Npc_1_19_4 extends Npc {
         team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));
 
         Component vanillaComponent = PaperAdventure.asVanilla(MiniMessage.miniMessage().deserialize(finalDisplayName));
+        npc.setCustomName(Component.empty());
         if (data.getDisplayName().equalsIgnoreCase("<empty>")) {
-            npc.setCustomName(Component.empty());
             npc.setCustomNameVisible(false);
             team.setNameTagVisibility(Team.Visibility.NEVER);
         } else {
-            npc.setCustomName(vanillaComponent);
             npc.setCustomNameVisible(true);
             team.setNameTagVisibility(Team.Visibility.ALWAYS);
         }

--- a/implementation_1_19_4/src/main/java/de/oliver/fancynpcs/v1_19_4/Npc_1_19_4.java
+++ b/implementation_1_19_4/src/main/java/de/oliver/fancynpcs/v1_19_4/Npc_1_19_4.java
@@ -156,14 +156,29 @@ public class Npc_1_19_4 extends Npc {
             finalDisplayName = PlaceholderAPI.setPlaceholders(serverPlayer.getBukkitEntity(), finalDisplayName);
         }
 
+        PlayerTeam team = new PlayerTeam(serverPlayer.getScoreboard(), "npc-" + localName);
+        team.getPlayers().clear();
+        team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().getName() : npc.getStringUUID());
+
+        boolean isTeamCreatedForPlayer = isTeamCreated.getOrDefault(serverPlayer.getUUID(), false);
+        serverPlayer.connection.send(ClientboundSetPlayerTeamPacket.createAddOrModifyPacket(team, !isTeamCreatedForPlayer));
+
+        if (!isTeamCreatedForPlayer) {
+            isTeamCreated.put(serverPlayer.getUUID(), true);
+        }
+        team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));
+
         Component vanillaComponent = PaperAdventure.asVanilla(MiniMessage.miniMessage().deserialize(finalDisplayName));
         if (data.getDisplayName().equalsIgnoreCase("<empty>")) {
             npc.setCustomName(Component.empty());
             npc.setCustomNameVisible(false);
+            team.setNameTagVisibility(Team.Visibility.NEVER);
         } else {
             npc.setCustomName(vanillaComponent);
             npc.setCustomNameVisible(true);
+            team.setNameTagVisibility(Team.Visibility.ALWAYS);
         }
+        team.setPlayerPrefix(vanillaComponent);
 
         if (npc instanceof ServerPlayer npcPlayer) {
             npcPlayer.listName = vanillaComponent;
@@ -179,29 +194,6 @@ public class Npc_1_19_4 extends Npc {
                 removeListed(playerInfoPacket);
             }
             serverPlayer.connection.send(playerInfoPacket);
-
-            // set custom name
-            String teamName = "npc-" + localName;
-
-            PlayerTeam team = new PlayerTeam(serverPlayer.getScoreboard(), teamName);
-            team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));
-            if (data.getDisplayName().equalsIgnoreCase("<empty>")) {
-                team.setNameTagVisibility(Team.Visibility.NEVER);
-            } else {
-                team.setNameTagVisibility(Team.Visibility.ALWAYS);
-            }
-            team.getPlayers().clear();
-            team.getPlayers().add(npcPlayer.getGameProfile().getName());
-            team.setPlayerPrefix(vanillaComponent);
-
-            boolean isTeamCreatedForPlayer = isTeamCreated.getOrDefault(serverPlayer.getUUID(), false);
-
-            ClientboundSetPlayerTeamPacket setPlayerTeamPacket = ClientboundSetPlayerTeamPacket.createAddOrModifyPacket(team, !isTeamCreatedForPlayer);
-            serverPlayer.connection.send(setPlayerTeamPacket);
-
-            if (!isTeamCreatedForPlayer) {
-                isTeamCreated.put(serverPlayer.getUUID(), true);
-            }
         }
 
         npc.setGlowingTag(data.isGlowing());

--- a/implementation_1_20_1/src/main/java/de/oliver/fancynpcs/v1_20_1/Npc_1_20_1.java
+++ b/implementation_1_20_1/src/main/java/de/oliver/fancynpcs/v1_20_1/Npc_1_20_1.java
@@ -156,14 +156,29 @@ public class Npc_1_20_1 extends Npc {
             finalDisplayName = PlaceholderAPI.setPlaceholders(serverPlayer.getBukkitEntity(), finalDisplayName);
         }
 
+        PlayerTeam team = new PlayerTeam(serverPlayer.getScoreboard(), "npc-" + localName);
+        team.getPlayers().clear();
+        team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().getName() : npc.getStringUUID());
+
+        boolean isTeamCreatedForPlayer = isTeamCreated.getOrDefault(serverPlayer.getUUID(), false);
+        serverPlayer.connection.send(ClientboundSetPlayerTeamPacket.createAddOrModifyPacket(team, !isTeamCreatedForPlayer));
+
+        if (!isTeamCreatedForPlayer) {
+            isTeamCreated.put(serverPlayer.getUUID(), true);
+        }
+        team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));
+
         Component vanillaComponent = PaperAdventure.asVanilla(MiniMessage.miniMessage().deserialize(finalDisplayName));
         if (data.getDisplayName().equalsIgnoreCase("<empty>")) {
             npc.setCustomName(Component.empty());
             npc.setCustomNameVisible(false);
+            team.setNameTagVisibility(Team.Visibility.NEVER);
         } else {
             npc.setCustomName(vanillaComponent);
             npc.setCustomNameVisible(true);
+            team.setNameTagVisibility(Team.Visibility.ALWAYS);
         }
+        team.setPlayerPrefix(vanillaComponent);
 
         if (npc instanceof ServerPlayer npcPlayer) {
             npcPlayer.listName = vanillaComponent;
@@ -179,29 +194,6 @@ public class Npc_1_20_1 extends Npc {
                 removeListed(playerInfoPacket);
             }
             serverPlayer.connection.send(playerInfoPacket);
-
-            // set custom name
-            String teamName = "npc-" + localName;
-
-            PlayerTeam team = new PlayerTeam(serverPlayer.getScoreboard(), teamName);
-            team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));
-            if (data.getDisplayName().equalsIgnoreCase("<empty>")) {
-                team.setNameTagVisibility(Team.Visibility.NEVER);
-            } else {
-                team.setNameTagVisibility(Team.Visibility.ALWAYS);
-            }
-            team.getPlayers().clear();
-            team.getPlayers().add(npcPlayer.getGameProfile().getName());
-            team.setPlayerPrefix(vanillaComponent);
-
-            boolean isTeamCreatedForPlayer = isTeamCreated.getOrDefault(serverPlayer.getUUID(), false);
-
-            ClientboundSetPlayerTeamPacket setPlayerTeamPacket = ClientboundSetPlayerTeamPacket.createAddOrModifyPacket(team, !isTeamCreatedForPlayer);
-            serverPlayer.connection.send(setPlayerTeamPacket);
-
-            if (!isTeamCreatedForPlayer) {
-                isTeamCreated.put(serverPlayer.getUUID(), true);
-            }
         }
 
         npc.setGlowingTag(data.isGlowing());

--- a/implementation_1_20_1/src/main/java/de/oliver/fancynpcs/v1_20_1/Npc_1_20_1.java
+++ b/implementation_1_20_1/src/main/java/de/oliver/fancynpcs/v1_20_1/Npc_1_20_1.java
@@ -169,12 +169,11 @@ public class Npc_1_20_1 extends Npc {
         team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));
 
         Component vanillaComponent = PaperAdventure.asVanilla(MiniMessage.miniMessage().deserialize(finalDisplayName));
+        npc.setCustomName(Component.empty());
         if (data.getDisplayName().equalsIgnoreCase("<empty>")) {
-            npc.setCustomName(Component.empty());
             npc.setCustomNameVisible(false);
             team.setNameTagVisibility(Team.Visibility.NEVER);
         } else {
-            npc.setCustomName(vanillaComponent);
             npc.setCustomNameVisible(true);
             team.setNameTagVisibility(Team.Visibility.ALWAYS);
         }

--- a/src/main/java/de/oliver/fancynpcs/commands/NpcCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/NpcCMD.java
@@ -472,11 +472,6 @@ public class NpcCMD implements CommandExecutor, TabCompleter {
                     return false;
                 }
 
-                if (npc.getData().getType() != EntityType.PLAYER) {
-                    MessageHelper.error(sender, "Npc's type must be Player to do this");
-                    return false;
-                }
-
                 boolean glowing;
                 try {
                     glowing = Boolean.parseBoolean(args[2]);
@@ -511,11 +506,6 @@ public class NpcCMD implements CommandExecutor, TabCompleter {
                 Npc npc = FancyNpcs.getInstance().getNpcManager().getNpc(name);
                 if (npc == null) {
                     MessageHelper.error(sender, "Could not find npc");
-                    return false;
-                }
-
-                if (npc.getData().getType() != EntityType.PLAYER) {
-                    MessageHelper.error(sender, "Npc's type must be Player to do this");
                     return false;
                 }
 


### PR DESCRIPTION
Enables glowing for all entities. Also fixes a bug where the first NPC update call for a player would cause some unknown team packet warnings in the client logs.