### PR TITLE
Implement dynamic skin mirroring

### DIFF
--- a/api/src/main/java/de/oliver/fancynpcs/api/NpcData.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/NpcData.java
@@ -34,6 +34,7 @@ public class NpcData {
     private float interactionCooldown;
     private Map<NpcAttribute, String> attributes;
     private boolean isDirty;
+    private boolean mirrorSkin;
 
     public NpcData(
             String id,
@@ -55,7 +56,8 @@ public class NpcData {
             String serverCommand,
             String playerCommand,
             float interactionCooldown,
-            Map<NpcAttribute, String> attributes
+            Map<NpcAttribute, String> attributes,
+            boolean mirrorSkin
     ) {
         this.id = id;
         this.name = name;
@@ -77,6 +79,7 @@ public class NpcData {
         this.messages = messages;
         this.interactionCooldown = interactionCooldown;
         this.attributes = attributes;
+        this.mirrorSkin = mirrorSkin;
         this.isDirty = true;
     }
 
@@ -102,6 +105,7 @@ public class NpcData {
         this.interactionCooldown = 0;
         this.equipment = new HashMap<>();
         this.attributes = new HashMap<>();
+        this.mirrorSkin = false;
         this.isDirty = true;
     }
 
@@ -305,6 +309,16 @@ public class NpcData {
         for (NpcAttribute attribute : attributes.keySet()) {
             attribute.apply(npc, attributes.get(attribute));
         }
+    }
+
+    public boolean isMirrorSkin() {
+        return mirrorSkin;
+    }
+
+    public NpcData setMirrorSkin(boolean mirrorSkin) {
+        this.mirrorSkin = mirrorSkin;
+        isDirty = true;
+        return this;
     }
 
     public boolean isDirty() {

--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcModifyEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcModifyEvent.java
@@ -93,5 +93,6 @@ public class NpcModifyEvent extends Event implements Cancellable {
         ATTRIBUTE,
         COLLIDABLE,
         INTERACTION_COOLDOWN,
+        MIRROR_SKIN,
     }
 }

--- a/implementation_1_20_2/src/main/java/de/oliver/fancynpcs/v1_20_2/Npc_1_20_2.java
+++ b/implementation_1_20_2/src/main/java/de/oliver/fancynpcs/v1_20_2/Npc_1_20_2.java
@@ -24,6 +24,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ClientInformation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerLoginPacketListenerImpl;
 import net.minecraft.world.entity.Display;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -107,7 +108,7 @@ public class Npc_1_20_2 extends Npc {
                 actions.add(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LISTED);
             }
 
-            ClientboundPlayerInfoUpdatePacket playerInfoPacket = new ClientboundPlayerInfoUpdatePacket(actions, getEntry(npcPlayer));
+            ClientboundPlayerInfoUpdatePacket playerInfoPacket = new ClientboundPlayerInfoUpdatePacket(actions, getEntry(npcPlayer, serverPlayer));
             serverPlayer.connection.send(playerInfoPacket);
 
             if (data.isSpawnEntity()) {
@@ -211,7 +212,7 @@ public class Npc_1_20_2 extends Npc {
                 actions.add(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LISTED);
             }
 
-            ClientboundPlayerInfoUpdatePacket playerInfoPacket = new ClientboundPlayerInfoUpdatePacket(actions, getEntry(npcPlayer));
+            ClientboundPlayerInfoUpdatePacket playerInfoPacket = new ClientboundPlayerInfoUpdatePacket(actions, getEntry(npcPlayer, serverPlayer));
             serverPlayer.connection.send(playerInfoPacket);
         }
 
@@ -284,10 +285,17 @@ public class Npc_1_20_2 extends Npc {
         serverPlayer.connection.send(rotateHeadPacket);
     }
 
-    private ClientboundPlayerInfoUpdatePacket.Entry getEntry(ServerPlayer npcPlayer) {
+    private ClientboundPlayerInfoUpdatePacket.Entry getEntry(ServerPlayer npcPlayer, ServerPlayer viewer) {
+        GameProfile profile = npcPlayer.getGameProfile();
+        if (data.isMirrorSkin() && ServerLoginPacketListenerImpl.isValidUsername(viewer.getGameProfile().getName())) {
+            GameProfile newProfile = new GameProfile(profile.getId(), profile.getName());
+            newProfile.getProperties().putAll(viewer.getGameProfile().getProperties());
+            profile = newProfile;
+        }
+
         return new ClientboundPlayerInfoUpdatePacket.Entry(
                 npcPlayer.getUUID(),
-                npcPlayer.getGameProfile(),
+                profile,
                 data.isShowInTab(),
                 69,
                 npcPlayer.gameMode.getGameModeForPlayer(),

--- a/implementation_1_20_4/src/main/java/de/oliver/fancynpcs/v1_20_4/Npc_1_20_4.java
+++ b/implementation_1_20_4/src/main/java/de/oliver/fancynpcs/v1_20_4/Npc_1_20_4.java
@@ -107,7 +107,7 @@ public class Npc_1_20_4 extends Npc {
                 actions.add(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LISTED);
             }
 
-            ClientboundPlayerInfoUpdatePacket playerInfoPacket = new ClientboundPlayerInfoUpdatePacket(actions, getEntry(npcPlayer));
+            ClientboundPlayerInfoUpdatePacket playerInfoPacket = new ClientboundPlayerInfoUpdatePacket(actions, getEntry(npcPlayer, serverPlayer));
             serverPlayer.connection.send(playerInfoPacket);
 
             if (data.isSpawnEntity()) {
@@ -211,7 +211,7 @@ public class Npc_1_20_4 extends Npc {
                 actions.add(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LISTED);
             }
 
-            ClientboundPlayerInfoUpdatePacket playerInfoPacket = new ClientboundPlayerInfoUpdatePacket(actions, getEntry(npcPlayer));
+            ClientboundPlayerInfoUpdatePacket playerInfoPacket = new ClientboundPlayerInfoUpdatePacket(actions, getEntry(npcPlayer, serverPlayer));
             serverPlayer.connection.send(playerInfoPacket);
         }
 
@@ -284,10 +284,17 @@ public class Npc_1_20_4 extends Npc {
         serverPlayer.connection.send(rotateHeadPacket);
     }
 
-    private ClientboundPlayerInfoUpdatePacket.Entry getEntry(ServerPlayer npcPlayer) {
+    private ClientboundPlayerInfoUpdatePacket.Entry getEntry(ServerPlayer npcPlayer, ServerPlayer viewer) {
+        GameProfile profile = npcPlayer.getGameProfile();
+        if (data.isMirrorSkin() && net.minecraft.world.entity.player.Player.isValidUsername(viewer.getGameProfile().getName())) {
+            GameProfile newProfile = new GameProfile(profile.getId(), profile.getName());
+            newProfile.getProperties().putAll(viewer.getGameProfile().getProperties());
+            profile = newProfile;
+        }
+
         return new ClientboundPlayerInfoUpdatePacket.Entry(
                 npcPlayer.getUUID(),
-                npcPlayer.getGameProfile(),
+                profile,
                 data.isShowInTab(),
                 69,
                 npcPlayer.gameMode.getGameModeForPlayer(),

--- a/src/main/java/de/oliver/fancynpcs/NpcManagerImpl.java
+++ b/src/main/java/de/oliver/fancynpcs/NpcManagerImpl.java
@@ -136,6 +136,7 @@ public class NpcManagerImpl implements NpcManager {
             npcConfig.set("npcs." + data.getId() + ".messages", data.getMessages());
             npcConfig.set("npcs." + data.getId() + ".message", null);
             npcConfig.set("npcs." + data.getId() + ".interactionCooldown", data.getInteractionCooldown());
+            npcConfig.set("npcs." + data.getId() + ".mirrorSkin", data.isMirrorSkin());
 
             if (data.getSkin() != null) {
                 npcConfig.set("npcs." + data.getId() + ".skin.identifier", data.getSkin().getIdentifier());
@@ -242,6 +243,7 @@ public class NpcManagerImpl implements NpcManager {
 
             List<String> messages = npcConfig.getStringList("npcs." + id + ".messages");
             float interactionCooldown = (float) npcConfig.getDouble("npcs." + id + ".interactionCooldown", 0);
+            boolean mirrorSkin = npcConfig.getBoolean("npcs." + id + ".mirrorSkin");
 
             Map<NpcAttribute, String> attributes = new HashMap<>();
             if (npcConfig.isConfigurationSection("npcs." + id + ".attributes")) {
@@ -266,7 +268,7 @@ public class NpcManagerImpl implements NpcManager {
                 messages.add(message);
             }
 
-            NpcData data = new NpcData(id, name, creator, displayName, skin, location, showInTab, spawnEntity, collidable, glowing, glowingColor, type, new HashMap<>(), turnToPlayer, null, messages, serverCommand, playerCommand, interactionCooldown, attributes);
+            NpcData data = new NpcData(id, name, creator, displayName, skin, location, showInTab, spawnEntity, collidable, glowing, glowingColor, type, new HashMap<>(), turnToPlayer, null, messages, serverCommand, playerCommand, interactionCooldown, attributes, mirrorSkin);
             Npc npc = npcAdapter.apply(data);
 
             if (npcConfig.isConfigurationSection("npcs." + id + ".equipment")) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/CopyCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/CopyCMD.java
@@ -64,7 +64,8 @@ public class CopyCMD implements Subcommand {
                         npc.getData().getServerCommand(),
                         npc.getData().getPlayerCommand(),
                         npc.getData().getInteractionCooldown(),
-                        npc.getData().getAttributes()
+                        npc.getData().getAttributes(),
+                        npc.getData().isMirrorSkin()
                 ));
 
         NpcCreateEvent npcCreateEvent = new NpcCreateEvent(copied, player);

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/MirrorSkinCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/MirrorSkinCMD.java
@@ -1,0 +1,73 @@
+package de.oliver.fancynpcs.commands.npc;
+
+import de.oliver.fancylib.LanguageConfig;
+import de.oliver.fancylib.MessageHelper;
+import de.oliver.fancynpcs.FancyNpcs;
+import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.api.events.NpcModifyEvent;
+import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class MirrorSkinCMD implements Subcommand {
+
+    private final LanguageConfig lang = FancyNpcs.getInstance().getLanguageConfig();
+
+    @Override
+    public List<String> tabcompletion(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+        if (args.length == 3) {
+            return Stream.of("true", "false")
+                    .filter(input -> input.toLowerCase().startsWith(args[2].toLowerCase()))
+                    .toList();
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
+        if (args.length < 3) {
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
+            return false;
+        }
+
+
+        if (npc == null) {
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
+            return false;
+        }
+
+        boolean mirrorSkin;
+        try {
+            mirrorSkin = Boolean.parseBoolean(args[2]);
+        } catch (Exception e) {
+            MessageHelper.error(receiver, lang.get("npc-command-wrong_usage"));
+            return false;
+        }
+
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.MIRROR_SKIN, mirrorSkin, receiver);
+        npcModifyEvent.callEvent();
+
+        if (!npcModifyEvent.isCancelled()) {
+            npc.getData().setMirrorSkin(mirrorSkin);
+            npc.removeForAll();
+            npc.create();
+            npc.spawnForAll();
+
+            if (mirrorSkin) {
+                MessageHelper.success(receiver, lang.get("npc-command-mirrorSkin-true"));
+            } else {
+                MessageHelper.success(receiver, lang.get("npc-command-mirrorSkin-false"));
+            }
+        } else {
+            MessageHelper.error(receiver, lang.get("npc-command-mirrorSkin-cancelled"));
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/NpcCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/NpcCMD.java
@@ -31,6 +31,7 @@ public class NpcCMD extends Command {
     private final Subcommand teleportCMD = new TeleportCMD();
     private final Subcommand turnToPlayerCMD = new TurnToPlayerCMD();
     private final Subcommand typeCMD = new TypeCMD();
+    private final Subcommand mirrorSkinCMD = new MirrorSkinCMD();
 
     public NpcCMD() {
         super("npc");
@@ -47,7 +48,7 @@ public class NpcCMD extends Command {
         List<String> suggestions = new ArrayList<>();
 
         if (args.length == 1) {
-            suggestions.addAll(Stream.of("help", "info", "message", "create", "remove", "copy", "skin", "movehere", "teleport", "displayName", "equipment", "playerCommand", "serverCommand", "showInTab", "glowing", "glowingColor", "collidable", "list", "turnToPlayer", "type", "attribute", "interactionCooldown")
+            suggestions.addAll(Stream.of("help", "info", "message", "create", "remove", "copy", "skin", "movehere", "teleport", "displayName", "equipment", "playerCommand", "serverCommand", "showInTab", "glowing", "glowingColor", "collidable", "list", "turnToPlayer", "type", "attribute", "interactionCooldown", "mirrorSkin")
                     .filter(input -> input.toLowerCase().startsWith(args[0].toLowerCase()))
                     .toList());
 
@@ -86,6 +87,7 @@ public class NpcCMD extends Command {
             case "teleport" -> teleportCMD.tabcompletion(p, npc, args);
             case "turntoplayer" -> turnToPlayerCMD.tabcompletion(p, npc, args);
             case "type" -> typeCMD.tabcompletion(p, npc, args);
+            case "mirrorskin" -> mirrorSkinCMD.tabcompletion(p, npc, args);
 
             default -> Collections.emptyList();
         };
@@ -124,6 +126,7 @@ public class NpcCMD extends Command {
             MessageHelper.info(sender, lang.get("npc-command-help-turnToPlayer"));
             MessageHelper.info(sender, lang.get("npc-command-help-attribute"));
             MessageHelper.info(sender, lang.get("npc-command-help-interactionCooldown"));
+            MessageHelper.info(sender, lang.get("npc-command-help-mirrorSkin"));
 
             return true;
         }
@@ -231,6 +234,10 @@ public class NpcCMD extends Command {
 
             case "attribute" -> {
                 return attributeCMD.run(sender, npc, args);
+            }
+
+            case "mirrorskin" -> {
+                return mirrorSkinCMD.run(sender, npc, args);
             }
 
             default -> {

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -32,6 +32,7 @@ messages:
   npc-command-help-turnToPlayer: ' - /npc turnToPlayer (name) (true|false) <dark_gray>- <white>Whether the NPC will turn to you or not'
   npc-command-help-attribute: ' - /npc attribute (name) (attribute) (value) <dark_gray>- <white>Set certain npc attributes'
   npc-command-help-interactionCooldown: ' - /npc interactionCooldown (name) (seconds) <dark_gray>- <white>Set the interaction cooldown (0 = disabled)'
+  npc_command-help-mirrorSkin: ' - /npc mirrorSkin (name) (true|false) <dark_gray>- <white>Whether the NPC will mirror the skin of the viewing player'
   npc-command-list-header: <b>All NPCs:</b>
   npc-command-list-no-npcs: There are no NPCs. Use '/npc create' to create one
   npc-command-list-tp-hover: <hover:show_text:'<gray><i>Click to teleport</i></gray>'><click:run_command:'{tp_cmd}'> - {name} ({x}/{y}/{z})</click></hover>
@@ -76,3 +77,6 @@ messages:
   npc-command-attribute-success: Successfully set the attribute
   npc-command-interactioncooldown-updated: Successfully updated the interaction cooldown
   npc-command-teleport-success: Successfully teleported npc
+  npc_command-mirrorSkin-true: NPC will now mirror the skin of the viewer
+  npc_command-mirrorSkin-false: NPC will no longer mirror the skin of the viewer
+  npc_command-mirrorSkin-cancelled: Modification has been cancelled


### PR DESCRIPTION
Allows for NPCs to mirror the skin of the player that the packet is being sent to. This probably could've been added to the skin command, but this way was more straight forward.

I've only tested this against 1.20.1 and an online mode server.
![example](https://i.yive.dev/tEitltkDwXRcE91V.png)