### PR TITLE
add NpcStartLookingEvent and NpcStopLookingEvent

### DIFF
--- a/api/src/main/java/de/oliver/fancynpcs/api/Npc.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/Npc.java
@@ -22,6 +22,7 @@ public abstract class Npc {
     private static final char[] localNameChars = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'k', 'l', 'm', 'n', 'o', 'r'};
     protected final Map<UUID, Boolean> isTeamCreated = new HashMap<>();
     protected final Map<UUID, Boolean> isVisibleForPlayer = new HashMap<>();
+    protected final Map<UUID, Boolean> isLookingAtPlayer = new HashMap<>();
     protected NpcData data;
     protected boolean saveToFile;
 
@@ -156,6 +157,10 @@ public abstract class Npc {
 
     public Map<UUID, Boolean> getIsVisibleForPlayer() {
         return isVisibleForPlayer;
+    }
+
+    public Map<UUID, Boolean> getIsLookingAtPlayer() {
+        return isLookingAtPlayer;
     }
 
     public boolean isDirty() {

--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcLookEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcLookEvent.java
@@ -1,0 +1,60 @@
+package de.oliver.fancynpcs.api.events;
+
+import de.oliver.fancynpcs.api.Npc;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Is fired when NPC starts looking at a player.
+ */
+public class NpcLookEvent extends Event implements Cancellable {
+
+    private static final HandlerList handlerList = new HandlerList();
+    @NotNull
+    private final Npc npc;
+    @NotNull
+    private final Player player;
+    private boolean isCancelled;
+
+    public NpcLookEvent(@NotNull Npc npc, @NotNull Player player) {
+        this.npc = npc;
+        this.player = player;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
+    }
+
+    /**
+     * @return the modified npc
+     */
+    public @NotNull Npc getNpc() {
+        return npc;
+    }
+
+    /**
+     * @return the player who interacted with the npc
+     */
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.isCancelled = cancel;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return handlerList;
+    }
+
+}

--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcStartLookingEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcStartLookingEvent.java
@@ -27,14 +27,14 @@ public class NpcStartLookingEvent extends Event {
     }
 
     /**
-     * @return the modified npc
+     * @return the npc that started looking at a player
      */
     public @NotNull Npc getNpc() {
         return npc;
     }
 
     /**
-     * @return the player who interacted with the npc
+     * @return the player who npc started looking at
      */
     public @NotNull Player getPlayer() {
         return player;

--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcStartLookingEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcStartLookingEvent.java
@@ -2,7 +2,6 @@ package de.oliver.fancynpcs.api.events;
 
 import de.oliver.fancynpcs.api.Npc;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -10,16 +9,15 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Is fired when NPC starts looking at a player.
  */
-public class NpcLookEvent extends Event implements Cancellable {
+public class NpcStartLookingEvent extends Event {
 
     private static final HandlerList handlerList = new HandlerList();
     @NotNull
     private final Npc npc;
     @NotNull
     private final Player player;
-    private boolean isCancelled;
 
-    public NpcLookEvent(@NotNull Npc npc, @NotNull Player player) {
+    public NpcStartLookingEvent(@NotNull Npc npc, @NotNull Player player) {
         this.npc = npc;
         this.player = player;
     }
@@ -40,16 +38,6 @@ public class NpcLookEvent extends Event implements Cancellable {
      */
     public @NotNull Player getPlayer() {
         return player;
-    }
-
-    @Override
-    public boolean isCancelled() {
-        return isCancelled;
-    }
-
-    @Override
-    public void setCancelled(boolean cancel) {
-        this.isCancelled = cancel;
     }
 
     @Override

--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcStopLookingEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcStopLookingEvent.java
@@ -27,14 +27,14 @@ public class NpcStopLookingEvent extends Event {
     }
 
     /**
-     * @return the modified npc
+     * @return the npc that stopped looking at a player
      */
     public @NotNull Npc getNpc() {
         return npc;
     }
 
     /**
-     * @return the player who interacted with the npc
+     * @return the player who npc stopped looking at
      */
     public @NotNull Player getPlayer() {
         return player;

--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcStopLookingEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcStopLookingEvent.java
@@ -1,0 +1,48 @@
+package de.oliver.fancynpcs.api.events;
+
+import de.oliver.fancynpcs.api.Npc;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Is fired when NPC stops looking at a player.
+ */
+public class NpcStopLookingEvent extends Event {
+
+    private static final HandlerList handlerList = new HandlerList();
+    @NotNull
+    private final Npc npc;
+    @NotNull
+    private final Player player;
+
+    public NpcStopLookingEvent(@NotNull Npc npc, @NotNull Player player) {
+        this.npc = npc;
+        this.player = player;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
+    }
+
+    /**
+     * @return the modified npc
+     */
+    public @NotNull Npc getNpc() {
+        return npc;
+    }
+
+    /**
+     * @return the player who interacted with the npc
+     */
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return handlerList;
+    }
+
+}

--- a/src/main/java/de/oliver/fancynpcs/FancyNpcs.java
+++ b/src/main/java/de/oliver/fancynpcs/FancyNpcs.java
@@ -15,6 +15,7 @@ import de.oliver.fancynpcs.api.NpcManager;
 import de.oliver.fancynpcs.commands.FancyNpcsCMD;
 import de.oliver.fancynpcs.commands.npc.NpcCMD;
 import de.oliver.fancynpcs.listeners.PlayerJoinListener;
+import de.oliver.fancynpcs.listeners.PlayerQuitListener;
 import de.oliver.fancynpcs.listeners.PlayerUseUnknownEntityListener;
 import de.oliver.fancynpcs.tracker.NpcTracker;
 import de.oliver.fancynpcs.v1_19_4.Npc_1_19_4;
@@ -148,6 +149,7 @@ public class FancyNpcs extends JavaPlugin implements FancyNpcsPlugin {
 
         // register listeners
         pluginManager.registerEvents(new PlayerJoinListener(), instance);
+        pluginManager.registerEvents(new PlayerQuitListener(), instance);
         pluginManager.registerEvents(new PlayerUseUnknownEntityListener(), instance);
 
         // using bungee plugin channel

--- a/src/main/java/de/oliver/fancynpcs/listeners/PlayerQuitListener.java
+++ b/src/main/java/de/oliver/fancynpcs/listeners/PlayerQuitListener.java
@@ -2,6 +2,8 @@ package de.oliver.fancynpcs.listeners;
 
 import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.api.events.NpcStopLookingEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -10,10 +12,12 @@ public class PlayerQuitListener implements Listener {
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
-        // Changing isLookingAtPlayer state (of event player) to false.
-        // This allows the NpcLookEvent to be called when player joins back. (Because otherwise, state would remain true and no change would be detected)
         for (Npc npc : FancyNpcs.getInstance().getNpcManagerImpl().getAllNpcs()) {
+            // Changing isLookingAtPlayer state (of event player) to false.
+            // This allows the NpcStartLookingEvent to be called when player joins back. (Because otherwise, state would remain true and no change would be detected)
             npc.getIsLookingAtPlayer().put(event.getPlayer().getUniqueId(), false);
+            // Calling NpcStopLookingEvent.
+            Bukkit.getPluginManager().callEvent(new NpcStopLookingEvent(npc, event.getPlayer()));
         }
     }
 }

--- a/src/main/java/de/oliver/fancynpcs/listeners/PlayerQuitListener.java
+++ b/src/main/java/de/oliver/fancynpcs/listeners/PlayerQuitListener.java
@@ -1,0 +1,19 @@
+package de.oliver.fancynpcs.listeners;
+
+import de.oliver.fancynpcs.FancyNpcs;
+import de.oliver.fancynpcs.api.Npc;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class PlayerQuitListener implements Listener {
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        // Changing isLookingAtPlayer state (of event player) to false.
+        // This allows the NpcLookEvent to be called when player joins back. (Because otherwise, state would remain true and no change would be detected)
+        for (Npc npc : FancyNpcs.getInstance().getNpcManagerImpl().getAllNpcs()) {
+            npc.getIsLookingAtPlayer().put(event.getPlayer().getUniqueId(), false);
+        }
+    }
+}

--- a/src/main/java/de/oliver/fancynpcs/tracker/NpcTracker.java
+++ b/src/main/java/de/oliver/fancynpcs/tracker/NpcTracker.java
@@ -3,7 +3,8 @@ package de.oliver.fancynpcs.tracker;
 import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.NpcData;
-import de.oliver.fancynpcs.api.events.NpcLookEvent;
+import de.oliver.fancynpcs.api.events.NpcStartLookingEvent;
+import de.oliver.fancynpcs.api.events.NpcStopLookingEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -50,14 +51,18 @@ public class NpcTracker extends BukkitRunnable {
                     Boolean wasPreviouslyLooking = npc.getIsLookingAtPlayer().put(player.getUniqueId(), true);
                     // Comparing the previous state with current state to prevent event from being called continuously.
                     if (wasPreviouslyLooking == null || !wasPreviouslyLooking) {
-                        // Calling the event from the main thread.
+                        // Calling NpcStartLookingEvent from the main thread.
                         Bukkit.getScheduler().runTask(FancyNpcs.getInstance(), () -> {
-                            Bukkit.getPluginManager().callEvent(new NpcLookEvent(npc, player));
+                            Bukkit.getPluginManager().callEvent(new NpcStartLookingEvent(npc, player));
                         });
                     }
                 // Updating state if changed.
-                } else if (npc.getIsLookingAtPlayer().getOrDefault(player.getUniqueId(), false)) {
+                } else if (npcData.isTurnToPlayer() && npc.getIsLookingAtPlayer().getOrDefault(player.getUniqueId(), false)) {
                     npc.getIsLookingAtPlayer().put(player.getUniqueId(), false);
+                    // Calling NpcStopLookingEvent from the main thread.
+                    Bukkit.getScheduler().runTask(FancyNpcs.getInstance(), () -> {
+                        Bukkit.getPluginManager().callEvent(new NpcStopLookingEvent(npc, player));
+                    });
                 }
             }
         }


### PR DESCRIPTION
Useful for triggering some action (eg. sending a chat message) when player approaches NPC.

Implementation required creating new `HashMap<UUID, Boolean>` inside NPC object to properly detect when NPC starts and stops looking at a player. Plugin now also listens for PlayerQuitEvent to mark disconnected players as no longer being "seen/targetted" by NPCs.

