### PR TITLE
Replace map with weak set

### DIFF
--- a/api/src/main/java/de/oliver/fancynpcs/api/Npc.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/Npc.java
@@ -13,15 +13,15 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.util.Vector;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 public abstract class Npc {
 
     private static final char[] localNameChars = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'k', 'l', 'm', 'n', 'o', 'r'};
-    protected final Map<UUID, Boolean> isTeamCreated = new HashMap<>();
-    protected final Map<UUID, Boolean> isVisibleForPlayer = new HashMap<>();
+    protected final Set<Player> isTeamCreated = Collections.newSetFromMap(new WeakHashMap<>());
+    protected final Set<Player> isVisibleForPlayer = Collections.newSetFromMap(new WeakHashMap<>());
     protected NpcData data;
     protected boolean saveToFile;
 
@@ -150,11 +150,11 @@ public abstract class Npc {
 
     public abstract float getEyeHeight();
 
-    public Map<UUID, Boolean> getIsTeamCreated() {
+    public Set<Player> getIsTeamCreated() {
         return isTeamCreated;
     }
 
-    public Map<UUID, Boolean> getIsVisibleForPlayer() {
+    public Set<Player> getIsVisibleForPlayer() {
         return isVisibleForPlayer;
     }
 

--- a/implementation_1_19_4/src/main/java/de/oliver/fancynpcs/v1_19_4/Npc_1_19_4.java
+++ b/implementation_1_19_4/src/main/java/de/oliver/fancynpcs/v1_19_4/Npc_1_19_4.java
@@ -110,7 +110,7 @@ public class Npc_1_19_4 extends Npc {
             serverPlayer.connection.send(addEntityPacket);
         }
 
-        isVisibleForPlayer.put(player.getUniqueId(), true);
+        isVisibleForPlayer.add(player);
 
         update(player);
     }
@@ -128,7 +128,7 @@ public class Npc_1_19_4 extends Npc {
         ClientboundRemoveEntitiesPacket removeEntitiesPacket = new ClientboundRemoveEntitiesPacket(npc.getId());
         serverPlayer.connection.send(removeEntitiesPacket);
 
-        isVisibleForPlayer.put(serverPlayer.getUUID(), false);
+        isVisibleForPlayer.remove(player);
     }
 
     @Override
@@ -150,7 +150,7 @@ public class Npc_1_19_4 extends Npc {
 
     @Override
     public void update(Player player) {
-        if (!isVisibleForPlayer.getOrDefault(player.getUniqueId(), false)) {
+        if (!isVisibleForPlayer.contains(player)) {
             return;
         }
 
@@ -165,11 +165,11 @@ public class Npc_1_19_4 extends Npc {
         team.getPlayers().clear();
         team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().getName() : npc.getStringUUID());
 
-        boolean isTeamCreatedForPlayer = isTeamCreated.getOrDefault(serverPlayer.getUUID(), false);
+        boolean isTeamCreatedForPlayer = isTeamCreated.contains(player);
         serverPlayer.connection.send(ClientboundSetPlayerTeamPacket.createAddOrModifyPacket(team, !isTeamCreatedForPlayer));
 
         if (!isTeamCreatedForPlayer) {
-            isTeamCreated.put(serverPlayer.getUUID(), true);
+            isTeamCreated.add(player);
         }
         team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));
 
@@ -230,7 +230,7 @@ public class Npc_1_19_4 extends Npc {
 
     @Override
     protected void refreshEntityData(Player player) {
-        if (!isVisibleForPlayer.getOrDefault(player.getUniqueId(), false)) {
+        if (!isVisibleForPlayer.contains(player)) {
             return;
         }
 

--- a/implementation_1_20_1/src/main/java/de/oliver/fancynpcs/v1_20_1/Npc_1_20_1.java
+++ b/implementation_1_20_1/src/main/java/de/oliver/fancynpcs/v1_20_1/Npc_1_20_1.java
@@ -111,7 +111,7 @@ public class Npc_1_20_1 extends Npc {
             serverPlayer.connection.send(addEntityPacket);
         }
 
-        isVisibleForPlayer.put(player.getUniqueId(), true);
+        isVisibleForPlayer.add(player);
 
         update(player);
     }
@@ -129,7 +129,7 @@ public class Npc_1_20_1 extends Npc {
         ClientboundRemoveEntitiesPacket removeEntitiesPacket = new ClientboundRemoveEntitiesPacket(npc.getId());
         serverPlayer.connection.send(removeEntitiesPacket);
 
-        isVisibleForPlayer.put(serverPlayer.getUUID(), false);
+        isVisibleForPlayer.remove(player);
     }
 
     @Override
@@ -151,7 +151,7 @@ public class Npc_1_20_1 extends Npc {
 
     @Override
     public void update(Player player) {
-        if (!isVisibleForPlayer.getOrDefault(player.getUniqueId(), false)) {
+        if (!isVisibleForPlayer.contains(player)) {
             return;
         }
 
@@ -166,11 +166,11 @@ public class Npc_1_20_1 extends Npc {
         team.getPlayers().clear();
         team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().getName() : npc.getStringUUID());
 
-        boolean isTeamCreatedForPlayer = isTeamCreated.getOrDefault(serverPlayer.getUUID(), false);
+        boolean isTeamCreatedForPlayer = isTeamCreated.contains(player);
         serverPlayer.connection.send(ClientboundSetPlayerTeamPacket.createAddOrModifyPacket(team, !isTeamCreatedForPlayer));
 
         if (!isTeamCreatedForPlayer) {
-            isTeamCreated.put(serverPlayer.getUUID(), true);
+            isTeamCreated.add(player);
         }
         team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));
 
@@ -233,7 +233,7 @@ public class Npc_1_20_1 extends Npc {
 
     @Override
     protected void refreshEntityData(Player player) {
-        if (!isVisibleForPlayer.getOrDefault(player.getUniqueId(), false)) {
+        if (!isVisibleForPlayer.contains(player)) {
             return;
         }
 

--- a/src/main/java/de/oliver/fancynpcs/listeners/PlayerJoinListener.java
+++ b/src/main/java/de/oliver/fancynpcs/listeners/PlayerJoinListener.java
@@ -16,7 +16,6 @@ public class PlayerJoinListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         for (Npc npc : FancyNpcs.getInstance().getNpcManagerImpl().getAllNpcs()) {
-            npc.getIsTeamCreated().put(event.getPlayer().getUniqueId(), false);
             npc.spawn(event.getPlayer());
         }
 

--- a/src/main/java/de/oliver/fancynpcs/tracker/NpcTracker.java
+++ b/src/main/java/de/oliver/fancynpcs/tracker/NpcTracker.java
@@ -29,7 +29,7 @@ public class NpcTracker extends BukkitRunnable {
                     continue;
                 }
 
-                boolean isCurrentlyVisible = npc.getIsVisibleForPlayer().getOrDefault(player.getUniqueId(), false);
+                boolean isCurrentlyVisible = npc.getIsVisibleForPlayer().contains(player);
                 if (playerLocation.getWorld() != npcLocation.getWorld()) {
                     if (isCurrentlyVisible) {
                         npc.remove(player);


### PR DESCRIPTION
Current implementation never removes player UUIDs from maps and uses `Map` for things that can be replaced with `Set`.
This PR replaced `Map` with `Set` (with *weak set* created via `WeakHash`, Java [does not](https://stackoverflow.com/questions/4062919) have native weak sets) and stores `Player` objects insteads of `UUID`s which should be [automatically cleaned](https://docs.oracle.com/javase/8/docs/api/java/lang/ref/WeakReference.html) when player is not online and Garbage Collector is running in any free time.