### PR TITLE
Added support for other CommandSenders

### DIFF
--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcCreateEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcCreateEvent.java
@@ -1,6 +1,7 @@
 package de.oliver.fancynpcs.api.events;
 
 import de.oliver.fancynpcs.api.Npc;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -16,12 +17,12 @@ public class NpcCreateEvent extends Event implements Cancellable {
     @NotNull
     private final Npc npc;
     @NotNull
-    private final Player player;
+    private final CommandSender creator;
     private boolean isCancelled;
 
-    public NpcCreateEvent(@NotNull Npc npc, @NotNull Player player) {
+    public NpcCreateEvent(@NotNull Npc npc, @NotNull CommandSender creator) {
         this.npc = npc;
-        this.player = player;
+        this.creator = creator;
     }
 
     public static HandlerList getHandlerList() {
@@ -38,8 +39,8 @@ public class NpcCreateEvent extends Event implements Cancellable {
     /**
      * @return the player who created the npc
      */
-    public @NotNull Player getPlayer() {
-        return player;
+    public @NotNull CommandSender getCreator() {
+        return creator;
     }
 
     @Override

--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcModifyEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcModifyEvent.java
@@ -1,7 +1,7 @@
 package de.oliver.fancynpcs.api.events;
 
 import de.oliver.fancynpcs.api.Npc;
-import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -20,14 +20,14 @@ public class NpcModifyEvent extends Event implements Cancellable {
     @NotNull
     private final Object newValue;
     @NotNull
-    private final Player player;
+    private final CommandSender modifier;
     private boolean isCancelled;
 
-    public NpcModifyEvent(@NotNull Npc npc, @NotNull NpcModification modification, Object newValue, @NotNull Player player) {
+    public NpcModifyEvent(@NotNull Npc npc, @NotNull NpcModification modification, Object newValue, @NotNull CommandSender modifier) {
         this.npc = npc;
         this.modification = modification;
         this.newValue = newValue;
-        this.player = player;
+        this.modifier = modifier;
     }
 
     public static HandlerList getHandlerList() {
@@ -56,10 +56,10 @@ public class NpcModifyEvent extends Event implements Cancellable {
     }
 
     /**
-     * @return the player who modified the npc
+     * @return the sender who modified the npc
      */
-    public @NotNull Player getPlayer() {
-        return player;
+    public @NotNull CommandSender getModifier() {
+        return modifier;
     }
 
     @Override

--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcRemoveEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcRemoveEvent.java
@@ -1,7 +1,7 @@
 package de.oliver.fancynpcs.api.events;
 
 import de.oliver.fancynpcs.api.Npc;
-import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -16,12 +16,12 @@ public class NpcRemoveEvent extends Event implements Cancellable {
     @NotNull
     private final Npc npc;
     @NotNull
-    private final Player player;
+    private final CommandSender receiver;
     private boolean isCancelled;
 
-    public NpcRemoveEvent(@NotNull Npc npc, @NotNull Player player) {
+    public NpcRemoveEvent(@NotNull Npc npc, @NotNull CommandSender receiver) {
         this.npc = npc;
-        this.player = player;
+        this.receiver = receiver;
     }
 
     public static HandlerList getHandlerList() {
@@ -38,8 +38,8 @@ public class NpcRemoveEvent extends Event implements Cancellable {
     /**
      * @return the player who removed the npc
      */
-    public @NotNull Player getPlayer() {
-        return player;
+    public @NotNull CommandSender getSender() {
+        return receiver;
     }
 
     @Override

--- a/src/main/java/de/oliver/fancynpcs/commands/Subcommand.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/Subcommand.java
@@ -1,6 +1,7 @@
 package de.oliver.fancynpcs.commands;
 
 import de.oliver.fancynpcs.api.Npc;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -11,6 +12,6 @@ public interface Subcommand {
 
     List<String> tabcompletion(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args);
 
-    boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args);
+    boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args);
 
 }

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/AttributeCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/AttributeCMD.java
@@ -8,6 +8,7 @@ import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.NpcAttribute;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -50,14 +51,14 @@ public class AttributeCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
         if (args.length < 4) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
@@ -71,17 +72,17 @@ public class AttributeCMD implements Subcommand {
 
         NpcAttribute attribute = attributeManager.getAttributeByName(npc.getData().getType(), attributeName);
         if (attribute == null) {
-            MessageHelper.error(player, lang.get("npc-command-attribute-attribute-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-command-attribute-attribute-not-found"));
             return false;
         }
 
         if (!attribute.getTypes().contains(npc.getData().getType())) {
-            MessageHelper.error(player, lang.get("npc-command-attribute-wrong-entity-type"));
+            MessageHelper.error(receiver, lang.get("npc-command-attribute-wrong-entity-type"));
             return false;
         }
 
         if (!attribute.isValidValue(value)) {
-            MessageHelper.error(player, lang.get("npc-command-attribute-invalid-value"));
+            MessageHelper.error(receiver, lang.get("npc-command-attribute-invalid-value"));
             return false;
         }
 
@@ -89,14 +90,14 @@ public class AttributeCMD implements Subcommand {
         npcModifyEvent.callEvent();
 
         if (npcModifyEvent.isCancelled()) {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
             return false;
         }
 
         npc.getData().addAttribute(attribute, value);
         npc.updateForAll();
 
-        MessageHelper.success(player, lang.get("npc-command-attribute-success"));
+        MessageHelper.success(receiver, lang.get("npc-command-attribute-success"));
 
         return false;
     }

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/AttributeCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/AttributeCMD.java
@@ -86,7 +86,7 @@ public class AttributeCMD implements Subcommand {
             return false;
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.ATTRIBUTE, new Object[]{attribute, value}, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.ATTRIBUTE, new Object[]{attribute, value}, receiver);
         npcModifyEvent.callEvent();
 
         if (npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/CollidableCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/CollidableCMD.java
@@ -42,7 +42,7 @@ public class CollidableCMD implements Subcommand {
             return false;
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.COLLIDABLE, collidable, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.COLLIDABLE, collidable, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/CollidableCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/CollidableCMD.java
@@ -6,6 +6,7 @@ import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,14 +23,14 @@ public class CollidableCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
@@ -37,7 +38,7 @@ public class CollidableCMD implements Subcommand {
         try {
             collidable = Boolean.parseBoolean(args[2]);
         } catch (Exception e) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
@@ -49,12 +50,12 @@ public class CollidableCMD implements Subcommand {
             npc.updateForAll();
 
             if (collidable) {
-                MessageHelper.success(player, lang.get("npc-command-collidable-true"));
+                MessageHelper.success(receiver, lang.get("npc-command-collidable-true"));
             } else {
-                MessageHelper.success(player, lang.get("npc-command-collidable-false"));
+                MessageHelper.success(receiver, lang.get("npc-command-collidable-false"));
             }
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/CopyCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/CopyCMD.java
@@ -27,7 +27,7 @@ public class CopyCMD implements Subcommand {
     @Override
     public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (!(receiver instanceof Player player)) {
-            MessageHelper.error(receiver, lang.get("npc-command.only_player"));
+            MessageHelper.error(receiver, lang.get("npc-command.only-players"));
             return false;
         }
 

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/CopyCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/CopyCMD.java
@@ -26,6 +26,11 @@ public class CopyCMD implements Subcommand {
 
     @Override
     public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
+        if (!(receiver instanceof Player player)) {
+            MessageHelper.error(receiver, lang.get("npc-command.only_player"));
+            return false;
+        }
+
         if (npc == null) {
             MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/CopyCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/CopyCMD.java
@@ -7,6 +7,7 @@ import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.NpcData;
 import de.oliver.fancynpcs.api.events.NpcCreateEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,14 +25,14 @@ public class CopyCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
@@ -66,9 +67,9 @@ public class CopyCMD implements Subcommand {
             FancyNpcs.getInstance().getNpcManagerImpl().registerNpc(copied);
             copied.spawnForAll();
 
-            MessageHelper.success(player, lang.get("npc-command-copy-success"));
+            MessageHelper.success(receiver, lang.get("npc-command-copy-success"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-copy-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-copy-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/CreateCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/CreateCMD.java
@@ -26,7 +26,7 @@ public class CreateCMD implements Subcommand {
     @Override
     public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (!(receiver instanceof Player player)) {
-            MessageHelper.error(receiver, lang.get("npc-command.only_player"));
+            MessageHelper.error(receiver, lang.get("npc-command.only-players"));
             return false;
         }
 

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/CreateCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/CreateCMD.java
@@ -7,6 +7,7 @@ import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.NpcData;
 import de.oliver.fancynpcs.api.events.NpcCreateEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,17 +24,17 @@ public class CreateCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         String name = args[1];
 
         if (FancyNpcs.PLAYER_NPCS_FEATURE_FLAG.isEnabled()) {
             if (FancyNpcs.getInstance().getNpcManagerImpl().getNpc(name, player.getUniqueId()) != null) {
-                MessageHelper.error(player, lang.get("npc-command-create-name-already-exists"));
+                MessageHelper.error(receiver, lang.get("npc-command-create-name-already-exists"));
                 return false;
             }
         } else {
             if (FancyNpcs.getInstance().getNpcManagerImpl().getNpc(name) != null) {
-                MessageHelper.error(player, lang.get("npc-command-create-name-already-exists"));
+                MessageHelper.error(receiver, lang.get("npc-command-create-name-already-exists"));
                 return false;
             }
         }
@@ -53,9 +54,9 @@ public class CreateCMD implements Subcommand {
             FancyNpcs.getInstance().getNpcManagerImpl().registerNpc(createdNpc);
             createdNpc.spawnForAll();
 
-            MessageHelper.success(player, lang.get("npc-command-create-created"));
+            MessageHelper.success(receiver, lang.get("npc-command-create-created"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-create-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-create-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/CreateCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/CreateCMD.java
@@ -25,6 +25,11 @@ public class CreateCMD implements Subcommand {
 
     @Override
     public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
+        if (!(receiver instanceof Player player)) {
+            MessageHelper.error(receiver, lang.get("npc-command.only_player"));
+            return false;
+        }
+
         String name = args[1];
 
         if (FancyNpcs.PLAYER_NPCS_FEATURE_FLAG.isEnabled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/DisplayNameCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/DisplayNameCMD.java
@@ -40,7 +40,7 @@ public class DisplayNameCMD implements Subcommand {
         }
         displayName = displayName.substring(0, displayName.length() - 1);
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.DISPLAY_NAME, displayName, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.DISPLAY_NAME, displayName, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/DisplayNameCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/DisplayNameCMD.java
@@ -6,6 +6,7 @@ import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,14 +23,14 @@ public class DisplayNameCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
@@ -45,9 +46,9 @@ public class DisplayNameCMD implements Subcommand {
         if (!npcModifyEvent.isCancelled()) {
             npc.getData().setDisplayName(displayName.toString());
             npc.updateForAll();
-            MessageHelper.success(player, lang.get("npc-command-displayName-updated"));
+            MessageHelper.success(receiver, lang.get("npc-command-displayName-updated"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/EquipmentCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/EquipmentCMD.java
@@ -27,7 +27,7 @@ public class EquipmentCMD implements Subcommand {
     @Override
     public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (!(receiver instanceof Player player)) {
-            MessageHelper.error(receiver, lang.get("npc-command.only_player"));
+            MessageHelper.error(receiver, lang.get("npc-command.only-players"));
             return false;
         }
 

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/EquipmentCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/EquipmentCMD.java
@@ -7,6 +7,7 @@ import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.api.utils.NpcEquipmentSlot;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -24,15 +25,15 @@ public class EquipmentCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
@@ -40,7 +41,7 @@ public class EquipmentCMD implements Subcommand {
 
         NpcEquipmentSlot equipmentSlot = NpcEquipmentSlot.parse(slot);
         if (equipmentSlot == null) {
-            MessageHelper.error(player, lang.get("npc-command-equipment-invalid-slot"));
+            MessageHelper.error(receiver, lang.get("npc-command-equipment-invalid-slot"));
             return false;
         }
 
@@ -52,9 +53,9 @@ public class EquipmentCMD implements Subcommand {
         if (!npcModifyEvent.isCancelled()) {
             npc.getData().addEquipment(equipmentSlot, item);
             npc.updateForAll();
-            MessageHelper.success(player, lang.get("npc-command-equipment-updated"));
+            MessageHelper.success(receiver, lang.get("npc-command-equipment-updated"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/EquipmentCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/EquipmentCMD.java
@@ -26,6 +26,11 @@ public class EquipmentCMD implements Subcommand {
 
     @Override
     public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
+        if (!(receiver instanceof Player player)) {
+            MessageHelper.error(receiver, lang.get("npc-command.only_player"));
+            return false;
+        }
+
         if (args.length < 3) {
             MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
@@ -47,7 +52,7 @@ public class EquipmentCMD implements Subcommand {
 
         ItemStack item = player.getInventory().getItemInMainHand();
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.EQUIPMENT, new Object[]{equipmentSlot, item}, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.EQUIPMENT, new Object[]{equipmentSlot, item}, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/GlowingCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/GlowingCMD.java
@@ -6,6 +6,7 @@ import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,15 +23,15 @@ public class GlowingCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
@@ -38,7 +39,7 @@ public class GlowingCMD implements Subcommand {
         try {
             glowing = Boolean.parseBoolean(args[2]);
         } catch (Exception e) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
@@ -50,12 +51,12 @@ public class GlowingCMD implements Subcommand {
             npc.updateForAll();
 
             if (glowing) {
-                MessageHelper.success(player, lang.get("npc-command-glowing-true"));
+                MessageHelper.success(receiver, lang.get("npc-command-glowing-true"));
             } else {
-                MessageHelper.success(player, lang.get("npc-command-glowing-false"));
+                MessageHelper.success(receiver, lang.get("npc-command-glowing-false"));
             }
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/GlowingCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/GlowingCMD.java
@@ -43,7 +43,7 @@ public class GlowingCMD implements Subcommand {
             return false;
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.GLOWING, glowing, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.GLOWING, glowing, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/GlowingColorCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/GlowingColorCMD.java
@@ -7,6 +7,7 @@ import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,21 +24,21 @@ public class GlowingColorCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
         NamedTextColor color = NamedTextColor.NAMES.value(args[2]);
         if (color == null) {
-            MessageHelper.error(player, lang.get("npc-command-glowingColor-invalid"));
+            MessageHelper.error(receiver, lang.get("npc-command-glowingColor-invalid"));
             return false;
         }
 
@@ -47,9 +48,9 @@ public class GlowingColorCMD implements Subcommand {
         if (!npcModifyEvent.isCancelled()) {
             npc.getData().setGlowingColor(color);
             npc.updateForAll();
-            MessageHelper.success(player, lang.get("npc-command-glowingColor-updated"));
+            MessageHelper.success(receiver, lang.get("npc-command-glowingColor-updated"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/GlowingColorCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/GlowingColorCMD.java
@@ -42,7 +42,7 @@ public class GlowingColorCMD implements Subcommand {
             return false;
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.GLOWING_COLOR, color, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.GLOWING_COLOR, color, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/ListCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/ListCMD.java
@@ -5,6 +5,7 @@ import de.oliver.fancylib.MessageHelper;
 import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,13 +24,13 @@ public class ListCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
-        if (!player.hasPermission("fancynpcs.npc.list") && !player.hasPermission("fancynpcs.npc.*")) {
-            MessageHelper.error(player, lang.get("no-permission-subcommand"));
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
+        if (!receiver.hasPermission("fancynpcs.npc.list") && !receiver.hasPermission("fancynpcs.npc.*")) {
+            MessageHelper.error(receiver, lang.get("no-permission-subcommand"));
             return false;
         }
 
-        MessageHelper.info(player, lang.get("npc-command-list-header"));
+        MessageHelper.info(receiver, lang.get("npc-command-list-header"));
 
         Collection<Npc> allNpcs = FancyNpcs.getInstance().getNpcManagerImpl().getAllNpcs();
         if (FancyNpcs.PLAYER_NPCS_FEATURE_FLAG.isEnabled()) {
@@ -39,11 +40,11 @@ public class ListCMD implements Subcommand {
         }
 
         if (allNpcs.isEmpty()) {
-            MessageHelper.warning(player, lang.get("npc-command-list-no-npcs"));
+            MessageHelper.warning(receiver, lang.get("npc-command-list-no-npcs"));
         } else {
             final DecimalFormat df = new DecimalFormat("#########.##");
             for (Npc n : allNpcs) {
-                MessageHelper.info(player, lang.get(
+                MessageHelper.info(receiver, lang.get(
                                 "npc-command-list-tp-hover",
                                 "name", n.getData().getName(),
                                 "x", df.format(n.getData().getLocation().x()),

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/ListCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/ListCMD.java
@@ -33,7 +33,7 @@ public class ListCMD implements Subcommand {
         MessageHelper.info(receiver, lang.get("npc-command-list-header"));
 
         Collection<Npc> allNpcs = FancyNpcs.getInstance().getNpcManagerImpl().getAllNpcs();
-        if (FancyNpcs.PLAYER_NPCS_FEATURE_FLAG.isEnabled()) {
+        if (FancyNpcs.PLAYER_NPCS_FEATURE_FLAG.isEnabled() && receiver instanceof Player player) {
             allNpcs = allNpcs.stream()
                     .filter(n -> n.getData().getCreator().equals(player.getUniqueId()))
                     .toList();

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/MessageCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/MessageCMD.java
@@ -53,7 +53,7 @@ public class MessageCMD implements Subcommand {
             return false;
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.CUSTOM_MESSAGE, message, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.CUSTOM_MESSAGE, message, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/MessageCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/MessageCMD.java
@@ -6,6 +6,7 @@ import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,15 +25,15 @@ public class MessageCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
@@ -48,7 +49,7 @@ public class MessageCMD implements Subcommand {
         }
 
         if (hasIllegalCommand(message.toLowerCase())) {
-            MessageHelper.error(player, lang.get("illegal-command"));
+            MessageHelper.error(receiver, lang.get("illegal-command"));
             return false;
         }
 
@@ -57,9 +58,9 @@ public class MessageCMD implements Subcommand {
 
         if (!npcModifyEvent.isCancelled()) {
             npc.getData().setMessage(message);
-            MessageHelper.success(player, lang.get("npc-command-message-updated"));
+            MessageHelper.success(receiver, lang.get("npc-command-message-updated"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/MoveHereCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/MoveHereCMD.java
@@ -26,7 +26,7 @@ public class MoveHereCMD implements Subcommand {
     @Override
     public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (!(receiver instanceof Player player)) {
-            MessageHelper.error(receiver, lang.get("npc-command.only_player"));
+            MessageHelper.error(receiver, lang.get("npc-command.only-players"));
             return false;
         }
 

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/MoveHereCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/MoveHereCMD.java
@@ -25,6 +25,11 @@ public class MoveHereCMD implements Subcommand {
 
     @Override
     public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
+        if (!(receiver instanceof Player player)) {
+            MessageHelper.error(receiver, lang.get("npc-command.only_player"));
+            return false;
+        }
+
         if (npc == null) {
             MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
@@ -32,7 +37,7 @@ public class MoveHereCMD implements Subcommand {
 
         Location location = player.getLocation();
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.LOCATION, location, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.LOCATION, location, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/MoveHereCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/MoveHereCMD.java
@@ -7,6 +7,7 @@ import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
 import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,9 +24,9 @@ public class MoveHereCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
@@ -37,9 +38,9 @@ public class MoveHereCMD implements Subcommand {
         if (!npcModifyEvent.isCancelled()) {
             npc.getData().setLocation(location);
             npc.update(player);
-            MessageHelper.success(player, lang.get("npc-command-moveHere-moved"));
+            MessageHelper.success(receiver, lang.get("npc-command-moveHere-moved"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/NpcCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/NpcCMD.java
@@ -140,9 +140,13 @@ public class NpcCMD implements CommandExecutor, TabCompleter {
 
         String subcommand = args[0];
         String name = args[1];
-        Npc npc = FancyNpcs.PLAYER_NPCS_FEATURE_FLAG.isEnabled() ?
-                FancyNpcs.getInstance().getNpcManagerImpl().getNpc(name, p.getUniqueId()) :
-                FancyNpcs.getInstance().getNpcManagerImpl().getNpc(name);
+        Npc npc;
+        if (FancyNpcs.PLAYER_NPCS_FEATURE_FLAG.isEnabled() && sender instanceof Player player) {
+            npc = FancyNpcs.getInstance().getNpcManagerImpl().getNpc(name, player.getUniqueId());
+        } else {
+            npc = FancyNpcs.getInstance().getNpcManagerImpl().getNpc(name);
+        }
+
 
         if (!sender.hasPermission("fancynpcs.npc." + subcommand) && !sender.hasPermission("fancynpcs.npc.*")) {
             MessageHelper.error(sender, lang.get("no-permission-subcommand"));
@@ -151,12 +155,7 @@ public class NpcCMD implements CommandExecutor, TabCompleter {
 
         switch (subcommand.toLowerCase()) {
             case "create" -> {
-                if (!(sender instanceof Player p)) {
-                    MessageHelper.error(sender, lang.get("npc-command.only_player"));
-                    return false;
-                }
-
-                return new CreateCMD().run(p, null, args);
+                return new CreateCMD().run(sender, null, args);
             }
 
             case "remove" -> {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/NpcCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/NpcCMD.java
@@ -100,46 +100,41 @@ public class NpcCMD implements CommandExecutor, TabCompleter {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
 
-        if (!(sender instanceof Player p)) {
-            MessageHelper.error(sender, lang.get("npc-command.only_player"));
-            return false;
-        }
-
         if (args.length >= 1 && args[0].equalsIgnoreCase("help")) {
-            if (!p.hasPermission("fancynpcs.npc.help") && !p.hasPermission("fancynpcs.npc.*")) {
-                MessageHelper.error(p, lang.get("no-permission-subcommand"));
+            if (!sender.hasPermission("fancynpcs.npc.help") && !sender.hasPermission("fancynpcs.npc.*")) {
+                MessageHelper.error(sender, lang.get("no-permission-subcommand"));
                 return false;
             }
 
-            MessageHelper.info(p, lang.get("npc-command-help-header"));
-            MessageHelper.info(p, lang.get("npc-command-help-create"));
-            MessageHelper.info(p, lang.get("npc-command-help-remove"));
-            MessageHelper.info(p, lang.get("npc-command-help-copy"));
-            MessageHelper.info(p, lang.get("npc-command-help-list"));
-            MessageHelper.info(p, lang.get("npc-command-help-skin"));
-            MessageHelper.info(p, lang.get("npc-command-help-type"));
-            MessageHelper.info(p, lang.get("npc-command-help-moveHere"));
-            MessageHelper.info(p, lang.get("npc-command-help-displayName"));
-            MessageHelper.info(p, lang.get("npc-command-help-equipment"));
-            MessageHelper.info(p, lang.get("npc-command-help-message"));
-            MessageHelper.info(p, lang.get("npc-command-help-playerCommand"));
-            MessageHelper.info(p, lang.get("npc-command-help-serverCommand"));
-            MessageHelper.info(p, lang.get("npc-command-help-showInTab"));
-            MessageHelper.info(p, lang.get("npc-command-help-glowing"));
-            MessageHelper.info(p, lang.get("npc-command-help-glowingColor"));
-            MessageHelper.info(p, lang.get("npc-command-help-collidable"));
-            MessageHelper.info(p, lang.get("npc-command-help-turnToPlayer"));
-            MessageHelper.info(p, lang.get("npc-command-help-attribute"));
+            MessageHelper.info(sender, lang.get("npc-command-help-header"));
+            MessageHelper.info(sender, lang.get("npc-command-help-create"));
+            MessageHelper.info(sender, lang.get("npc-command-help-remove"));
+            MessageHelper.info(sender, lang.get("npc-command-help-copy"));
+            MessageHelper.info(sender, lang.get("npc-command-help-list"));
+            MessageHelper.info(sender, lang.get("npc-command-help-skin"));
+            MessageHelper.info(sender, lang.get("npc-command-help-type"));
+            MessageHelper.info(sender, lang.get("npc-command-help-moveHere"));
+            MessageHelper.info(sender, lang.get("npc-command-help-displayName"));
+            MessageHelper.info(sender, lang.get("npc-command-help-equipment"));
+            MessageHelper.info(sender, lang.get("npc-command-help-message"));
+            MessageHelper.info(sender, lang.get("npc-command-help-playerCommand"));
+            MessageHelper.info(sender, lang.get("npc-command-help-serverCommand"));
+            MessageHelper.info(sender, lang.get("npc-command-help-showInTab"));
+            MessageHelper.info(sender, lang.get("npc-command-help-glowing"));
+            MessageHelper.info(sender, lang.get("npc-command-help-glowingColor"));
+            MessageHelper.info(sender, lang.get("npc-command-help-collidable"));
+            MessageHelper.info(sender, lang.get("npc-command-help-turnToPlayer"));
+            MessageHelper.info(sender, lang.get("npc-command-help-attribute"));
 
             return true;
         }
 
         if (args.length >= 1 && args[0].equalsIgnoreCase("list")) {
-            return new ListCMD().run(p, null, args);
+            return new ListCMD().run(sender, null, args);
         }
 
         if (args.length < 2) {
-            MessageHelper.error(p, lang.get("wrong-usage"));
+            MessageHelper.error(sender, lang.get("wrong-usage"));
             return false;
         }
 
@@ -149,82 +144,87 @@ public class NpcCMD implements CommandExecutor, TabCompleter {
                 FancyNpcs.getInstance().getNpcManagerImpl().getNpc(name, p.getUniqueId()) :
                 FancyNpcs.getInstance().getNpcManagerImpl().getNpc(name);
 
-        if (!p.hasPermission("fancynpcs.npc." + subcommand) && !p.hasPermission("fancynpcs.npc.*")) {
-            MessageHelper.error(p, lang.get("no-permission-subcommand"));
+        if (!sender.hasPermission("fancynpcs.npc." + subcommand) && !sender.hasPermission("fancynpcs.npc.*")) {
+            MessageHelper.error(sender, lang.get("no-permission-subcommand"));
             return false;
         }
 
         switch (subcommand.toLowerCase()) {
             case "create" -> {
+                if (!(sender instanceof Player p)) {
+                    MessageHelper.error(sender, lang.get("npc-command.only_player"));
+                    return false;
+                }
+
                 return new CreateCMD().run(p, null, args);
             }
 
             case "remove" -> {
-                return new RemoveCMD().run(p, npc, args);
+                return new RemoveCMD().run(sender, npc, args);
             }
 
             case "copy" -> {
-                return new CopyCMD().run(p, npc, args);
+                return new CopyCMD().run(sender, npc, args);
             }
 
             case "movehere" -> {
-                return new MoveHereCMD().run(p, npc, args);
+                return new MoveHereCMD().run(sender, npc, args);
             }
 
             case "message" -> {
-                return new MessageCMD().run(p, npc, args);
+                return new MessageCMD().run(sender, npc, args);
             }
 
             case "skin" -> {
-                return new SkinCMD().run(p, npc, args);
+                return new SkinCMD().run(sender, npc, args);
             }
 
             case "displayname" -> {
-                return new DisplayNameCMD().run(p, npc, args);
+                return new DisplayNameCMD().run(sender, npc, args);
             }
 
             case "equipment" -> {
-                return new EquipmentCMD().run(p, npc, args);
+                return new EquipmentCMD().run(sender, npc, args);
             }
 
             case "servercommand" -> {
-                return new ServerCommandCMD().run(p, npc, args);
+                return new ServerCommandCMD().run(sender, npc, args);
             }
 
             case "playercommand" -> {
-                return new PlayerCommandCMD().run(p, npc, args);
+                return new PlayerCommandCMD().run(sender, npc, args);
             }
 
             case "showintab" -> {
-                return new ShowInTabCMD().run(p, npc, args);
+                return new ShowInTabCMD().run(sender, npc, args);
             }
 
             case "glowing" -> {
-                return new GlowingCMD().run(p, npc, args);
+                return new GlowingCMD().run(sender, npc, args);
             }
 
             case "glowingcolor" -> {
-                return new GlowingColorCMD().run(p, npc, args);
+                return new GlowingColorCMD().run(sender, npc, args);
             }
 
             case "collidable" -> {
-                return new CollidableCMD().run(p, npc, args);
+                return new CollidableCMD().run(sender, npc, args);
             }
 
             case "turntoplayer" -> {
-                return new TurnToPlayerCMD().run(p, npc, args);
+                return new TurnToPlayerCMD().run(sender, npc, args);
             }
 
             case "type" -> {
-                return new TypeCMD().run(p, npc, args);
+                return new TypeCMD().run(sender, npc, args);
             }
 
             case "attribute" -> {
-                return attributeCMD.run(p, npc, args);
+                return attributeCMD.run(sender, npc, args);
             }
 
             default -> {
-                MessageHelper.error(p, lang.get("wrong-usage"));
+                MessageHelper.error(sender, lang.get("wrong-usage"));
                 return false;
             }
         }

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/PlayerCommandCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/PlayerCommandCMD.java
@@ -18,20 +18,20 @@ public class PlayerCommandCMD implements Subcommand {
     private final LanguageConfig lang = FancyNpcs.getInstance().getLanguageConfig();
 
     @Override
-    public List<String> tabcompletion(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
+    public List<String> tabcompletion(@NotNull Player playedr, @Nullable Npc npc, @NotNull String[] args) {
         return null;
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
@@ -47,19 +47,19 @@ public class PlayerCommandCMD implements Subcommand {
 
         for (String blockedCommand : FancyNpcs.getInstance().getFancyNpcConfig().getBlockedCommands()) {
             if (cmd.toLowerCase().startsWith(blockedCommand.toLowerCase())) {
-                MessageHelper.error(player, lang.get("illegal-command"));
+                MessageHelper.error(receiver, lang.get("illegal-command"));
                 return false;
             }
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.PLAYER_COMMAND, cmd, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.PLAYER_COMMAND, cmd, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {
             npc.getData().setPlayerCommand(cmd);
-            MessageHelper.success(player, lang.get("npc-command-playerCommand-updated"));
+            MessageHelper.success(receiver, lang.get("npc-command-playerCommand-updated"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/PlayerCommandCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/PlayerCommandCMD.java
@@ -6,6 +6,7 @@ import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,7 +18,7 @@ public class PlayerCommandCMD implements Subcommand {
     private final LanguageConfig lang = FancyNpcs.getInstance().getLanguageConfig();
 
     @Override
-    public List<String> tabcompletion(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public List<String> tabcompletion(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         return null;
     }
 

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/RemoveCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/RemoveCMD.java
@@ -8,6 +8,7 @@ import de.oliver.fancynpcs.api.events.NpcRemoveEvent;
 import de.oliver.fancynpcs.api.events.NpcStopLookingEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,9 +25,9 @@ public class RemoveCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
@@ -44,9 +45,9 @@ public class RemoveCMD implements Subcommand {
                 }
             }
             FancyNpcs.getInstance().getNpcManagerImpl().removeNpc(npc);
-            MessageHelper.success(player, lang.get("npc-command-remove-removed"));
+            MessageHelper.success(receiver, lang.get("npc-command-remove-removed"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-remove-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-remove-cancelled"));
         }
 
         return false;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/RemoveCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/RemoveCMD.java
@@ -31,7 +31,7 @@ public class RemoveCMD implements Subcommand {
             return false;
         }
 
-        NpcRemoveEvent npcRemoveEvent = new NpcRemoveEvent(npc, player);
+        NpcRemoveEvent npcRemoveEvent = new NpcRemoveEvent(npc, receiver);
         npcRemoveEvent.callEvent();
         if (!npcRemoveEvent.isCancelled()) {
             npc.removeForAll();

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/ServerCommandCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/ServerCommandCMD.java
@@ -52,7 +52,7 @@ public class ServerCommandCMD implements Subcommand {
             }
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.SERVER_COMMAND, cmd, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.SERVER_COMMAND, cmd, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/ServerCommandCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/ServerCommandCMD.java
@@ -6,6 +6,7 @@ import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,15 +23,15 @@ public class ServerCommandCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
@@ -46,7 +47,7 @@ public class ServerCommandCMD implements Subcommand {
 
         for (String blockedCommand : FancyNpcs.getInstance().getFancyNpcConfig().getBlockedCommands()) {
             if (cmd.toLowerCase().startsWith(blockedCommand.toLowerCase())) {
-                MessageHelper.error(player, lang.get("illegal-command"));
+                MessageHelper.error(receiver, lang.get("illegal-command"));
                 return false;
             }
         }
@@ -56,9 +57,9 @@ public class ServerCommandCMD implements Subcommand {
 
         if (!npcModifyEvent.isCancelled()) {
             npc.getData().setServerCommand(cmd);
-            MessageHelper.success(player, lang.get("npc-command-serverCommand-updated"));
+            MessageHelper.success(receiver, lang.get("npc-command-serverCommand-updated"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/ShowInTabCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/ShowInTabCMD.java
@@ -6,6 +6,7 @@ import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -23,20 +24,20 @@ public class ShowInTabCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
         if (npc.getData().getType() != EntityType.PLAYER) {
-            MessageHelper.error(player, lang.get("npc-must-be-player"));
+            MessageHelper.error(receiver, lang.get("npc-must-be-player"));
             return false;
         }
 
@@ -45,7 +46,7 @@ public class ShowInTabCMD implements Subcommand {
             case "true" -> showInTab = true;
             case "false" -> showInTab = false;
             default -> {
-                MessageHelper.error(player, lang.get("npc-command-showInTab-invalid-argument"));
+                MessageHelper.error(receiver, lang.get("npc-command-showInTab-invalid-argument"));
                 return false;
             }
         }
@@ -54,7 +55,7 @@ public class ShowInTabCMD implements Subcommand {
         npcModifyEvent.callEvent();
 
         if (showInTab == npc.getData().isShowInTab()) {
-            MessageHelper.warning(player, lang.get("npc-command-showInTab-same"));
+            MessageHelper.warning(receiver, lang.get("npc-command-showInTab-same"));
             return false;
         }
 
@@ -63,12 +64,12 @@ public class ShowInTabCMD implements Subcommand {
             npc.updateForAll();
 
             if (showInTab) {
-                MessageHelper.success(player, lang.get("npc-command-showInTab-true"));
+                MessageHelper.success(receiver, lang.get("npc-command-showInTab-true"));
             } else {
-                MessageHelper.success(player, lang.get("npc-command-showInTab-false"));
+                MessageHelper.success(receiver, lang.get("npc-command-showInTab-false"));
             }
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/ShowInTabCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/ShowInTabCMD.java
@@ -51,7 +51,7 @@ public class ShowInTabCMD implements Subcommand {
             }
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.SHOW_IN_TAB, showInTab, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.SHOW_IN_TAB, showInTab, receiver);
         npcModifyEvent.callEvent();
 
         if (showInTab == npc.getData().isShowInTab()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/SkinCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/SkinCMD.java
@@ -8,6 +8,7 @@ import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.api.utils.SkinFetcher;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -26,9 +27,9 @@ public class SkinCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length != 3 && args.length != 2) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
@@ -36,19 +37,19 @@ public class SkinCMD implements Subcommand {
 
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
         if (npc.getData().getType() != EntityType.PLAYER) {
-            MessageHelper.error(player, lang.get("npc-must-be-player"));
+            MessageHelper.error(receiver, lang.get("npc-must-be-player"));
             return false;
         }
 
         if (SkinFetcher.SkinType.getType(skinName) == SkinFetcher.SkinType.UUID) {
             UUID uuid = UUIDFetcher.getUUID(skinName);
             if (uuid == null) {
-                MessageHelper.error(player, lang.get("npc-command-skin-invalid"));
+                MessageHelper.error(receiver, lang.get("npc-command-skin-invalid"));
                 return false;
             }
             skinName = uuid.toString();
@@ -56,9 +57,9 @@ public class SkinCMD implements Subcommand {
 
         SkinFetcher skinFetcher = new SkinFetcher(skinName);
         if (!skinFetcher.isLoaded()) {
-            MessageHelper.error(player, lang.get("npc-command-message-failed_header"));
-            MessageHelper.error(player, lang.get("npc-command-skin-failed_url"));
-            MessageHelper.error(player, lang.get("npc-command-skin-failed_limited"));
+            MessageHelper.error(receiver, lang.get("npc-command-message-failed_header"));
+            MessageHelper.error(receiver, lang.get("npc-command-skin-failed_url"));
+            MessageHelper.error(receiver, lang.get("npc-command-skin-failed_limited"));
             return false;
         }
 
@@ -70,9 +71,9 @@ public class SkinCMD implements Subcommand {
             npc.removeForAll();
             npc.create();
             npc.spawnForAll();
-            MessageHelper.success(player, lang.get("npc-command-skin-updated"));
+            MessageHelper.success(receiver, lang.get("npc-command-skin-updated"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/SkinCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/SkinCMD.java
@@ -33,7 +33,7 @@ public class SkinCMD implements Subcommand {
             return false;
         }
 
-        String skinName = args.length == 3 ? args[2] : player.getName();
+        String skinName = args.length == 3 ? args[2] : receiver instanceof Player player ? player.getName() : "Steve";
 
 
         if (npc == null) {
@@ -63,7 +63,7 @@ public class SkinCMD implements Subcommand {
             return false;
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.SKIN, skinFetcher, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.SKIN, skinFetcher, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/TurnToPlayerCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/TurnToPlayerCMD.java
@@ -43,7 +43,7 @@ public class TurnToPlayerCMD implements Subcommand {
             return false;
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.TURN_TO_PLAYER, turnToPlayer, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.TURN_TO_PLAYER, turnToPlayer, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/TurnToPlayerCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/TurnToPlayerCMD.java
@@ -6,6 +6,7 @@ import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,15 +23,15 @@ public class TurnToPlayerCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
@@ -38,7 +39,7 @@ public class TurnToPlayerCMD implements Subcommand {
         try {
             turnToPlayer = Boolean.parseBoolean(args[2]);
         } catch (Exception e) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
@@ -49,13 +50,13 @@ public class TurnToPlayerCMD implements Subcommand {
             npc.getData().setTurnToPlayer(turnToPlayer);
 
             if (turnToPlayer) {
-                MessageHelper.success(player, lang.get("npc-command-turnToPlayer-true"));
+                MessageHelper.success(receiver, lang.get("npc-command-turnToPlayer-true"));
             } else {
-                MessageHelper.success(player, lang.get("npc-command-turnToPlayer-false"));
+                MessageHelper.success(receiver, lang.get("npc-command-turnToPlayer-false"));
                 npc.updateForAll(); // move to default pos
             }
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/TypeCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/TypeCMD.java
@@ -42,7 +42,7 @@ public class TypeCMD implements Subcommand {
             return false;
         }
 
-        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.TYPE, type, player);
+        NpcModifyEvent npcModifyEvent = new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.TYPE, type, receiver);
         npcModifyEvent.callEvent();
 
         if (!npcModifyEvent.isCancelled()) {

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/TypeCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/TypeCMD.java
@@ -6,6 +6,7 @@ import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.events.NpcModifyEvent;
 import de.oliver.fancynpcs.commands.Subcommand;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -23,21 +24,21 @@ public class TypeCMD implements Subcommand {
     }
 
     @Override
-    public boolean run(@NotNull Player player, @Nullable Npc npc, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender receiver, @Nullable Npc npc, @NotNull String[] args) {
         if (args.length < 3) {
-            MessageHelper.error(player, lang.get("wrong-usage"));
+            MessageHelper.error(receiver, lang.get("wrong-usage"));
             return false;
         }
 
         if (npc == null) {
-            MessageHelper.error(player, lang.get("npc-not-found"));
+            MessageHelper.error(receiver, lang.get("npc-not-found"));
             return false;
         }
 
         EntityType type = EntityType.fromName(args[2].toLowerCase());
 
         if (type == null) {
-            MessageHelper.error(player, lang.get("npc-command-type-invalid"));
+            MessageHelper.error(receiver, lang.get("npc-command-type-invalid"));
             return false;
         }
 
@@ -58,9 +59,9 @@ public class TypeCMD implements Subcommand {
             npc.removeForAll();
             npc.create();
             npc.spawnForAll();
-            MessageHelper.success(player, lang.get("npc-command-type-updated"));
+            MessageHelper.success(receiver, lang.get("npc-command-type-updated"));
         } else {
-            MessageHelper.error(player, lang.get("npc-command-modification-cancelled"));
+            MessageHelper.error(receiver, lang.get("npc-command-modification-cancelled"));
         }
 
         return true;

--- a/src/main/java/de/oliver/fancynpcs/listeners/PlayerNpcsListener.java
+++ b/src/main/java/de/oliver/fancynpcs/listeners/PlayerNpcsListener.java
@@ -22,30 +22,33 @@ public class PlayerNpcsListener implements Listener {
 
     @EventHandler
     public void onNpcCreate(NpcCreateEvent event) {
-        Player p = event.getPlayer();
+        if (!(event.getCreator() instanceof Player player)) {
+            return;
+        }
+
         if (isUsingPlotSquared) {
-            PlotPlayer<?> plotPlayer = PlotSquared.platform().playerManager().getPlayer(p.getUniqueId());
+            PlotPlayer<?> plotPlayer = PlotSquared.platform().playerManager().getPlayer(player.getUniqueId());
             Plot currentPlot = plotPlayer.getCurrentPlot();
-            if ((currentPlot == null || !currentPlot.isOwner(p.getUniqueId())) && !p.hasPermission("fancynpcs.admin")) {
-                MessageHelper.error(p, "You are only allowed to create npcs on your plot");
+            if ((currentPlot == null || !currentPlot.isOwner(player.getUniqueId())) && !player.hasPermission("fancynpcs.admin")) {
+                MessageHelper.error(player, "You are only allowed to create npcs on your plot");
                 event.setCancelled(true);
                 return;
             }
         }
         int maxNpcs = FancyNpcs.getInstance().getFancyNpcConfig().getMaxNpcsPerPermission()
                 .entrySet().stream()
-                .filter(entry -> p.hasPermission(entry.getKey()))
+                .filter(entry -> player.hasPermission(entry.getKey()))
                 .max(Comparator.comparingInt(Map.Entry::getValue))
                 .map(Map.Entry::getValue)
                 .orElse(Integer.MAX_VALUE);
 
         int npcAmount = 0;
         for (Npc npc : FancyNpcs.getInstance().getNpcManager().getAllNpcs()) {
-            if (npc.getData().getCreator().equals(p.getUniqueId()))
+            if (npc.getData().getCreator().equals(player.getUniqueId()))
                 npcAmount++;
         }
-        if (npcAmount >= maxNpcs && !p.hasPermission("fancynpcs.admin")) {
-            MessageHelper.error(p, "You have reached the maximum amount of npcs");
+        if (npcAmount >= maxNpcs && !player.hasPermission("fancynpcs.admin")) {
+            MessageHelper.error(player, "You have reached the maximum amount of npcs");
             event.setCancelled(true);
             return;
         }
@@ -53,9 +56,12 @@ public class PlayerNpcsListener implements Listener {
 
     @EventHandler
     public void onNpcRemove(NpcRemoveEvent event) {
-        Player p = event.getPlayer();
-        if (!event.getNpc().getData().getCreator().equals(p.getUniqueId()) && !p.hasPermission("fancynpcs.admin")) {
-            MessageHelper.error(p, "You can only modify your npcs");
+        if (!(event.getSender() instanceof Player player)) {
+            return;
+        }
+
+        if (!event.getNpc().getData().getCreator().equals(player.getUniqueId()) && !player.hasPermission("fancynpcs.admin")) {
+            MessageHelper.error(player, "You can only modify your npcs");
             event.setCancelled(true);
             return;
         }
@@ -63,19 +69,21 @@ public class PlayerNpcsListener implements Listener {
 
     @EventHandler
     public void onNpcModify(NpcModifyEvent event) {
-        Player p = event.getPlayer();
+        if (!(event.getModifier() instanceof Player player)) {
+            return;
+        }
 
-        if (!event.getNpc().getData().getCreator().equals(p.getUniqueId()) && !p.hasPermission("fancynpcs.admin")) {
-            MessageHelper.error(p, "You can only modify your npcs");
+        if (!event.getNpc().getData().getCreator().equals(player.getUniqueId()) && !player.hasPermission("fancynpcs.admin")) {
+            MessageHelper.error(player, "You can only modify your npcs");
             event.setCancelled(true);
             return;
         }
         if (isUsingPlotSquared && event.getModification() == NpcModifyEvent.NpcModification.LOCATION) {
-            PlotPlayer<?> plotPlayer = PlotSquared.platform().playerManager().getPlayer(p.getUniqueId());
+            PlotPlayer<?> plotPlayer = PlotSquared.platform().playerManager().getPlayer(player.getUniqueId());
             Plot currentPlot = plotPlayer.getCurrentPlot();
 
-            if ((currentPlot == null || !currentPlot.isOwner(p.getUniqueId())) && !p.hasPermission("fancynpcs.admin")) {
-                MessageHelper.error(p, "You are only allowed to teleport npcs on your plot");
+            if ((currentPlot == null || !currentPlot.isOwner(player.getUniqueId())) && !player.hasPermission("fancynpcs.admin")) {
+                MessageHelper.error(player, "You are only allowed to teleport npcs on your plot");
                 event.setCancelled(true);
             }
         }


### PR DESCRIPTION
I've moved many of the commands over to being runnable on the console, some are unable to still for obvious reasons. I also ammended events and listeners inline with this.

People using the API will need to change from the getPlayer method, I could however, add a deprecated method that returns the player, or null if the command was ran by another CommandSender instance