### PR TITLE
Improve NPC interactions and extend NpcInteractEvent API

### DIFF
--- a/api/src/main/java/de/oliver/fancynpcs/api/Npc.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/Npc.java
@@ -6,6 +6,7 @@ import de.oliver.fancylib.LanguageConfig;
 import de.oliver.fancylib.MessageHelper;
 import de.oliver.fancylib.RandomUtils;
 import de.oliver.fancynpcs.api.events.NpcInteractEvent;
+import de.oliver.fancynpcs.api.events.NpcInteractEvent.InteractionType;
 import me.dave.chatcolorhandler.ChatColorHandler;
 import me.dave.chatcolorhandler.ModernChatColorHandler;
 import me.dave.chatcolorhandler.parsers.custom.PlaceholderAPIParser;
@@ -136,6 +137,10 @@ public abstract class Npc {
     }
 
     public void interact(Player player) {
+        interact(player, InteractionType.CUSTOM);
+    }
+
+    public void interact(Player player, InteractionType interactionType) {
         if (data.getInteractionCooldown() > 0) {
             if (lastPlayerInteraction.containsKey(player.getUniqueId())) {
                 long nextAllowedInteraction = lastPlayerInteraction.get(player.getUniqueId()) + Math.round(data.getInteractionCooldown() * 1000L);
@@ -152,7 +157,7 @@ public abstract class Npc {
             lastPlayerInteraction.put(player.getUniqueId(), System.currentTimeMillis());
         }
 
-        NpcInteractEvent npcInteractEvent = new NpcInteractEvent(this, data.getPlayerCommands(), data.getServerCommand(), data.getOnClick(), player);
+        NpcInteractEvent npcInteractEvent = new NpcInteractEvent(this, data.getPlayerCommands(), data.getServerCommand(), data.getOnClick(), player, interactionType);
         npcInteractEvent.callEvent();
 
         if (npcInteractEvent.isCancelled()) {

--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcInteractEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcInteractEvent.java
@@ -5,11 +5,12 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Consumer;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Is fired when a player interacts with a NPC
@@ -27,14 +28,16 @@ public class NpcInteractEvent extends Event implements Cancellable {
     private final Consumer<Player> onClick;
     @NotNull
     private final Player player;
+    private final InteractionType interactionType;
     private boolean isCancelled;
 
-    public NpcInteractEvent(@NotNull Npc npc, @Nullable List<String> playerCommands, @Nullable String serverCommand, @NotNull Consumer<Player> onClick, @NotNull Player player) {
+    public NpcInteractEvent(@NotNull Npc npc, @Nullable List<String> playerCommands, @Nullable String serverCommand, @NotNull Consumer<Player> onClick, @NotNull Player player, @Nullable InteractionType interactionType) {
         this.npc = npc;
         this.playerCommands = playerCommands;
         this.serverCommand = serverCommand;
         this.onClick = onClick;
         this.player = player;
+        this.interactionType = interactionType;
     }
 
     public static HandlerList getHandlerList() {
@@ -70,6 +73,13 @@ public class NpcInteractEvent extends Event implements Cancellable {
     }
 
     /**
+     * @return returns click type
+     */
+    public @NotNull InteractionType getInteractionType() {
+        return interactionType;
+    }
+
+    /**
      * @return the player who interacted with the npc
      */
     public @NotNull Player getPlayer() {
@@ -89,6 +99,13 @@ public class NpcInteractEvent extends Event implements Cancellable {
     @Override
     public @NotNull HandlerList getHandlers() {
         return handlerList;
+    }
+
+    public enum InteractionType {
+        LEFT_CLICK,
+        RIGHT_CLICK,
+        /** {@link InteractionType#CUSTOM InteractionType#CUSTOM} represents interactions invoked by the API. */
+        CUSTOM
     }
 
 }

--- a/api/src/main/java/de/oliver/fancynpcs/api/events/NpcInteractEvent.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/events/NpcInteractEvent.java
@@ -31,7 +31,7 @@ public class NpcInteractEvent extends Event implements Cancellable {
     private final InteractionType interactionType;
     private boolean isCancelled;
 
-    public NpcInteractEvent(@NotNull Npc npc, @Nullable List<String> playerCommands, @Nullable String serverCommand, @NotNull Consumer<Player> onClick, @NotNull Player player, @Nullable InteractionType interactionType) {
+    public NpcInteractEvent(@NotNull Npc npc, @Nullable List<String> playerCommands, @Nullable String serverCommand, @NotNull Consumer<Player> onClick, @NotNull Player player, @NotNull InteractionType interactionType) {
         this.npc = npc;
         this.playerCommands = playerCommands;
         this.serverCommand = serverCommand;
@@ -73,7 +73,7 @@ public class NpcInteractEvent extends Event implements Cancellable {
     }
 
     /**
-     * @return returns click type
+     * @return returns interaction type
      */
     public @NotNull InteractionType getInteractionType() {
         return interactionType;

--- a/implementation_1_19_4/src/main/java/de/oliver/fancynpcs/v1_19_4/PacketReader_1_19_4.java
+++ b/implementation_1_19_4/src/main/java/de/oliver/fancynpcs/v1_19_4/PacketReader_1_19_4.java
@@ -4,6 +4,7 @@ import de.oliver.fancylib.FancyLib;
 import de.oliver.fancylib.ReflectionUtils;
 import de.oliver.fancynpcs.api.FancyNpcsPlugin;
 import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.api.events.NpcInteractEvent;
 import de.oliver.fancynpcs.api.events.PacketReceivedEvent;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -71,16 +72,12 @@ public class PacketReader_1_19_4 implements Listener {
         boolean isInteract = action == ServerboundInteractPacket.ActionType.INTERACT_AT;
         Vector clickLoc = isInteract ? new Vector(0, 0, 0) : null;
 
-        if (npc.getData().getType() == EntityType.VILLAGER && hand == EquipmentSlot.HAND && clickLoc == null) {
-            npc.interact(event.getPlayer());
-            return;
-        }
-
-        if (!isAttack && (hand == EquipmentSlot.HAND || clickLoc != null)) {
-            return;
-        }
-
-        npc.interact(p);
+        // This can optionally be ALSO called for OFF-HAND slot. Making sure to run logic only ONCE.
+        if (hand == EquipmentSlot.HAND)
+            // This packet can be sent multiple times for interactions that are NOT attacks, making sure to run logic only ONCE.
+            if (isAttack || clickLoc == null)
+                // Further interaction handling is done by Npc#interact method...
+                npc.interact(event.getPlayer(), isAttack ? NpcInteractEvent.InteractionType.LEFT_CLICK : NpcInteractEvent.InteractionType.RIGHT_CLICK);
     }
 
 }

--- a/implementation_1_19_4/src/main/java/de/oliver/fancynpcs/v1_19_4/PacketReader_1_19_4.java
+++ b/implementation_1_19_4/src/main/java/de/oliver/fancynpcs/v1_19_4/PacketReader_1_19_4.java
@@ -12,12 +12,10 @@ import io.netty.handler.codec.MessageToMessageDecoder;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
 import net.minecraft.server.level.ServerPlayer;
 import org.bukkit.craftbukkit.v1_19_R3.entity.CraftPlayer;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.util.Vector;
 
 import java.util.List;
 

--- a/implementation_1_20/src/main/java/de/oliver/fancynpcs/v1_20/PacketReader_1_20.java
+++ b/implementation_1_20/src/main/java/de/oliver/fancynpcs/v1_20/PacketReader_1_20.java
@@ -4,6 +4,7 @@ import de.oliver.fancylib.FancyLib;
 import de.oliver.fancylib.ReflectionUtils;
 import de.oliver.fancynpcs.api.FancyNpcsPlugin;
 import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.api.events.NpcInteractEvent;
 import de.oliver.fancynpcs.api.events.PacketReceivedEvent;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -71,16 +72,12 @@ public class PacketReader_1_20 implements Listener {
         boolean isInteract = action == ServerboundInteractPacket.ActionType.INTERACT_AT;
         Vector clickLoc = isInteract ? new Vector(0, 0, 0) : null;
 
-        if (npc.getData().getType() == EntityType.VILLAGER && hand == EquipmentSlot.HAND && clickLoc == null) {
-            npc.interact(event.getPlayer());
-            return;
-        }
-
-        if (!isAttack && (hand == EquipmentSlot.HAND || clickLoc != null)) {
-            return;
-        }
-
-        npc.interact(p);
+        // This packet can optionally be ALSO sent for OFF-HAND slot. Making sure to run logic only ONCE.
+        if (hand == EquipmentSlot.HAND)
+            // This packet can be sent multiple times for interactions that are NOT attacks, making sure to run logic only ONCE.
+            if (isAttack || clickLoc == null)
+                // Further interaction handling is done by Npc#interact method...
+                npc.interact(event.getPlayer(), isAttack ? NpcInteractEvent.InteractionType.LEFT_CLICK : NpcInteractEvent.InteractionType.RIGHT_CLICK);
     }
 
 }

--- a/implementation_1_20/src/main/java/de/oliver/fancynpcs/v1_20/PacketReader_1_20.java
+++ b/implementation_1_20/src/main/java/de/oliver/fancynpcs/v1_20/PacketReader_1_20.java
@@ -12,12 +12,10 @@ import io.netty.handler.codec.MessageToMessageDecoder;
 import net.minecraft.network.protocol.game.ServerboundInteractPacket;
 import net.minecraft.server.level.ServerPlayer;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftPlayer;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.util.Vector;
 
 import java.util.List;
 

--- a/implementation_1_20/src/main/java/de/oliver/fancynpcs/v1_20/PacketReader_1_20.java
+++ b/implementation_1_20/src/main/java/de/oliver/fancynpcs/v1_20/PacketReader_1_20.java
@@ -46,36 +46,29 @@ public class PacketReader_1_20 implements Listener {
     }
 
     @EventHandler
-    public void onPacketReceived(PacketReceivedEvent event) {
-        if (!(event.getPacket() instanceof ServerboundInteractPacket interactPacket)) {
+    public void onPacketReceived(final PacketReceivedEvent event) {
+        // Skipping packets other than ServerboundInteractPacket...
+        if (!(event.getPacket() instanceof ServerboundInteractPacket interactPacket))
             return;
-        }
-
-        Player p = event.getPlayer();
-
-        String handStr = "MAIN_HAND";
-        if (interactPacket.getActionType() != ServerboundInteractPacket.ActionType.ATTACK) {
-            handStr = ReflectionUtils.getValue(ReflectionUtils.getValue(interactPacket, "b"), "a").toString(); // ServerboundInteractPacket.InteractionAction.hand
-        }
-
-        int entityId = interactPacket.getEntityId();
-        ServerboundInteractPacket.ActionType action = interactPacket.getActionType();
-        boolean isSneaking = interactPacket.isUsingSecondaryAction();
-
-        Npc npc = FancyNpcsPlugin.get().getNpcManager().getNpc(entityId);
-        if (npc == null) {
+        // Getting entity identifier.
+        final int entityId = interactPacket.getEntityId();
+        // Getting NPC from entity identifier.
+        final Npc npc = FancyNpcsPlugin.get().getNpcManager().getNpc(entityId);
+        // Skipping entities that are not FancyNpcs' NPCs...
+        if (npc == null)
             return;
-        }
-
-        EquipmentSlot hand = handStr.equals("MAIN_HAND") ? EquipmentSlot.HAND : EquipmentSlot.OFF_HAND;
-        boolean isAttack = action == ServerboundInteractPacket.ActionType.ATTACK;
-        boolean isInteract = action == ServerboundInteractPacket.ActionType.INTERACT_AT;
-        Vector clickLoc = isInteract ? new Vector(0, 0, 0) : null;
-
-        // This packet can optionally be ALSO sent for OFF-HAND slot. Making sure to run logic only ONCE.
+        // Getting interaction information.
+        final boolean isAttack = (interactPacket.getActionType() == ServerboundInteractPacket.ActionType.ATTACK);
+        final boolean isInteract = (interactPacket.getActionType() == ServerboundInteractPacket.ActionType.INTERACT_AT);
+        final EquipmentSlot hand = (interactPacket.getActionType() == ServerboundInteractPacket.ActionType.ATTACK)
+                ? EquipmentSlot.HAND
+                : ReflectionUtils.getValue(ReflectionUtils.getValue(interactPacket, "b"), "a").toString().equals("MAIN_HAND") // ServerboundInteractPacket.InteractionAction.hand
+                        ? EquipmentSlot.HAND
+                        : EquipmentSlot.OFF_HAND;
+        // This can optionally be ALSO called for OFF-HAND slot. Making sure to run logic only ONCE.
         if (hand == EquipmentSlot.HAND)
             // This packet can be sent multiple times for interactions that are NOT attacks, making sure to run logic only ONCE.
-            if (isAttack || clickLoc == null)
+            if (isAttack || !isInteract)
                 // Further interaction handling is done by Npc#interact method...
                 npc.interact(event.getPlayer(), isAttack ? NpcInteractEvent.InteractionType.LEFT_CLICK : NpcInteractEvent.InteractionType.RIGHT_CLICK);
     }

--- a/src/main/java/de/oliver/fancynpcs/FancyNpcs.java
+++ b/src/main/java/de/oliver/fancynpcs/FancyNpcs.java
@@ -192,12 +192,12 @@ public class FancyNpcs extends JavaPlugin implements FancyNpcsPlugin {
         pluginManager.registerEvents(new PlayerTeleportListener(), instance);
         pluginManager.registerEvents(new PlayerChangedWorldListener(), instance);
 
-        if (mcVersion.equals("1.19.4")) // use packet injection method
-            pluginManager.registerEvents(new PacketReader_1_19_4(), instance);
-        else if (mcVersion.equals("1.20"))
-            pluginManager.registerEvents(new PacketReader_1_20(), instance);
-        else
-            pluginManager.registerEvents(new PlayerUseUnknownEntityListener(), instance);
+        // use packet injection method
+        switch (mcVersion) {
+            case "1.19.4" -> pluginManager.registerEvents(new PacketReader_1_19_4(), instance);
+            case "1.20" -> pluginManager.registerEvents(new PacketReader_1_20(), instance);
+            default -> pluginManager.registerEvents(new PlayerUseUnknownEntityListener(), instance);
+        }
 
         if (PLAYER_NPCS_FEATURE_FLAG.isEnabled()) {
             pluginManager.registerEvents(new PlayerNpcsListener(), instance);

--- a/src/main/java/de/oliver/fancynpcs/listeners/PlayerUseUnknownEntityListener.java
+++ b/src/main/java/de/oliver/fancynpcs/listeners/PlayerUseUnknownEntityListener.java
@@ -3,30 +3,26 @@ package de.oliver.fancynpcs.listeners;
 import com.destroystokyo.paper.event.player.PlayerUseUnknownEntityEvent;
 import de.oliver.fancynpcs.FancyNpcs;
 import de.oliver.fancynpcs.api.Npc;
-import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.EquipmentSlot;
+
+import static de.oliver.fancynpcs.api.events.NpcInteractEvent.InteractionType;
 
 public class PlayerUseUnknownEntityListener implements Listener {
 
     @EventHandler
     public void onPlayerUseUnknownEntity(PlayerUseUnknownEntityEvent event) {
         Npc npc = FancyNpcs.getInstance().getNpcManagerImpl().getNpc(event.getEntityId());
-        if (npc == null) {
+        // Skipping entities that are not FancyNpcs' NPCs
+        if (npc == null)
             return;
-        }
-
-        if (npc.getData().getType() == EntityType.VILLAGER && event.getHand() == EquipmentSlot.HAND && event.getClickedRelativePosition() == null) {
-            npc.interact(event.getPlayer());
-            return;
-        }
-
-        if (!event.isAttack() && (event.getHand() == EquipmentSlot.HAND || event.getClickedRelativePosition() != null)) {
-            return;
-        }
-
-        npc.interact(event.getPlayer());
+        // PlayerUseUnknownEntityEvent can optionally be ALSO called for OFF-HAND slot. Making sure to run logic only ONCE.
+        if (event.getHand() == EquipmentSlot.HAND)
+            // PlayerUseUnknownEntityEvent can be called multiple times for interactions that are NOT attacks, making sure to run logic only ONCE.
+            if (event.isAttack() || event.getClickedRelativePosition() == null)
+                // Further interaction handling is done by Npc#interact method...
+                npc.interact(event.getPlayer(), event.isAttack() ? InteractionType.LEFT_CLICK : InteractionType.RIGHT_CLICK);
     }
 
 }

--- a/src/main/java/de/oliver/fancynpcs/listeners/PlayerUseUnknownEntityListener.java
+++ b/src/main/java/de/oliver/fancynpcs/listeners/PlayerUseUnknownEntityListener.java
@@ -12,8 +12,8 @@ import static de.oliver.fancynpcs.api.events.NpcInteractEvent.InteractionType;
 public class PlayerUseUnknownEntityListener implements Listener {
 
     @EventHandler
-    public void onPlayerUseUnknownEntity(PlayerUseUnknownEntityEvent event) {
-        Npc npc = FancyNpcs.getInstance().getNpcManagerImpl().getNpc(event.getEntityId());
+    public void onPlayerUseUnknownEntity(final PlayerUseUnknownEntityEvent event) {
+        final Npc npc = FancyNpcs.getInstance().getNpcManagerImpl().getNpc(event.getEntityId());
         // Skipping entities that are not FancyNpcs' NPCs
         if (npc == null)
             return;


### PR DESCRIPTION
1. NPC interactions logic has been cleaned-up a bit; this should also fix problem described in #91.
2. New method has been added: `NpcInteractEvent#getInteractionType`, which returns:
 a) `NpcInteractEvent.InteractionType.LEFT_CLICK` for left-click interactions.
 b) `NpcInteractEvent.InteractionType.RIGHT_CLICK` for right-click interactions.
 c) `NpcInteractEvent.InteractionType.CUSTOM` for interactions forced by API.

Marked as DRAFT because I have not *fully* tested these changes yet.