### PR TITLE
use testPermissionSilent when filtering command suggestions

### DIFF
--- a/src/main/java/de/oliver/fancynpcs/commands/npc/PlayerCommandCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/PlayerCommandCMD.java
@@ -181,7 +181,7 @@ public enum PlayerCommandCMD {
     @Suggestions("PlayerCommandCMD/commands") // Suggests allowed (non-blocked) commands accessible by the command sender.
     public Collection<String> suggestCommand(final CommandContext<CommandSender> context, final CommandInput input) {
         return Bukkit.getServer().getCommandMap().getKnownCommands().values().stream()
-                .filter(command -> !command.getName().contains(":") && command.testPermission(context.sender()) && !hasBlockedCommands(command.getName()))
+                .filter(command -> !command.getName().contains(":") && command.testPermissionSilent(context.sender()) && !hasBlockedCommands(command.getName()))
                 .map(org.bukkit.command.Command::getName)
                 .toList();
     }

--- a/src/main/java/de/oliver/fancynpcs/commands/npc/ServerCommandCMD.java
+++ b/src/main/java/de/oliver/fancynpcs/commands/npc/ServerCommandCMD.java
@@ -182,7 +182,7 @@ public enum ServerCommandCMD {
     @Suggestions("ServerCommandCMD/commands") // Suggests allowed (non-blocked) commands accessible by the command sender.
     public Collection<String> suggestCommand(final CommandContext<CommandSender> context, final CommandInput input) {
         return Bukkit.getServer().getCommandMap().getKnownCommands().values().stream()
-                .filter(command -> !command.getName().contains(":") && command.testPermission(context.sender()) && !hasBlockedCommands(command.getName()))
+                .filter(command -> !command.getName().contains(":") && command.testPermissionSilent(context.sender()) && !hasBlockedCommands(command.getName()))
                 .map(org.bukkit.command.Command::getName)
                 .toList();
     }


### PR DESCRIPTION
Because `testPermission(CommandSender)` sends error messages to the sender.