### PR TITLE
Use StreamSupport instead of Registry#stream on 1.20.1

### DIFF
--- a/implementation_1_20_1/src/main/java/de/oliver/fancynpcs/v1_20_1/attributes/BlockDisplayAttributes.java
+++ b/implementation_1_20_1/src/main/java/de/oliver/fancynpcs/v1_20_1/attributes/BlockDisplayAttributes.java
@@ -13,10 +13,11 @@ import org.bukkit.entity.EntityType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.StreamSupport;
 
 public class BlockDisplayAttributes {
 
-    private static final List<String> BLOCKS = Registry.MATERIAL.stream().filter(Material::isBlock).map(it -> it.key().value()).toList();
+    private static final List<String> BLOCKS = StreamSupport.stream(Registry.MATERIAL.spliterator(), false).filter(Material::isBlock).map(it -> it.key().value()).toList();
 
     public static List<NpcAttribute> getAllAttributes() {
         List<NpcAttribute> attributes = new ArrayList<>();


### PR DESCRIPTION
`Registry#stream` was added in last build for Paper 1.20.1, making the plugin unable to load on a server that use earlier version of said software. While only latest builds of Paper should be supported, this method can be replaced easily and 1.19.4 module is already using it.