### PR TITLE
Add missing dependencies to paper-plugin.yml

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,14 @@ paper {
             required = false
             load = PaperPluginDescription.RelativeLoadOrder.BEFORE
         }
+        register("MiniPlaceholders") {
+            required = false
+            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+        }
+        register("PlotSquared") {
+            required = false
+            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+        }
     }
 }
 


### PR DESCRIPTION
MiniPlaceholders and PlotSquared were missing from the server dependencies in `paper-plugin.yml` file, which made the plugin unable to access their API.