### PR TITLE
Relocated cloud command library, updated shadowJar & gradle

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java-library")
     id("maven-publish")
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 
     id("xyz.jpenilla.run-paper") version "2.2.4"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
     id("net.minecrell.plugin-yml.paper") version "0.6.0"
     id("io.papermc.hangar-publish-plugin") version "0.1.2"
     id("com.modrinth.minotaur") version "2.+"
@@ -94,8 +94,8 @@ tasks {
     }
 
     shadowJar {
+        relocate("org.incendo", "de.oliver")
         archiveClassifier.set("")
-
         dependsOn(":api:shadowJar")
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Relocated cloud duo to `java.lang.LinkageError` while using cloud library in another plugins so FancyNpcs has its own package name for cloud now 👍🏻 