### PR TITLE
Allow for formatted duration in wait action

### DIFF
--- a/api/src/main/java/de/oliver/fancynpcs/api/actions/types/WaitAction.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/actions/types/WaitAction.java
@@ -22,16 +22,16 @@ public class WaitAction extends NpcAction {
             return;
         }
 
-        int time;
+        long time;
         try {
-            time = Integer.parseInt(value);
+            time = Long.parseLong(value);
         } catch (NumberFormatException e) {
             FancyNpcsPlugin.get().getFancyLogger().warn("Invalid time value for wait action: " + value);
             return;
         }
 
         try {
-            Thread.sleep(time * 1000L);
+            Thread.sleep(time);
         } catch (InterruptedException e) {
             FancyNpcsPlugin.get().getFancyLogger().warn("Thread was interrupted while waiting");
         }


### PR DESCRIPTION
Adds support for formatted durations to the "wait" npc action.
E.g 
- 10s
- 5h20m3s
- 16d
Cloud duration parser seems a bit broken atm, allowing for durations like `10sh` or `5hd` 
Also milli seconds currently seem not to be supported at all (See https://github.com/Incendo/cloud/blob/3c83f9a680609299894406a2de2502209c16f113/cloud-core/src/main/java/org/incendo/cloud/parser/standard/DurationParser.java#L79-L119)