### PR TITLE
Prevent expiration if `timeToLive` is non-positive

### DIFF
--- a/api/src/main/java/de/oliver/fancynpcs/api/utils/SkinFetcher.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/utils/SkinFetcher.java
@@ -264,7 +264,7 @@ public final class SkinFetcher {
     @ApiStatus.Internal
     public record SkinCacheData(@NotNull SkinData skinData, long lastUpdated, long timeToLive) {
         public boolean isExpired() {
-            return System.currentTimeMillis() - lastUpdated > timeToLive;
+            return timeToLive > 0 && System.currentTimeMillis() - lastUpdated > timeToLive;
         }
     }
 }


### PR DESCRIPTION
This change will prevent skin expiration when `timeToLive` is manually edited to -1. 
After updating to the new version of the plugin, all skins broke, and this functionality would be useful.