### PR TITLE
Fix suggestion: #214 : Virtual Threads are not a good idea.

### DIFF
--- a/src/main/java/de/oliver/fancynpcs/FancyNpcs.java
+++ b/src/main/java/de/oliver/fancynpcs/FancyNpcs.java
@@ -468,7 +468,11 @@ public class FancyNpcs extends JavaPlugin implements FancyNpcsPlugin {
 
     @Override
     public Thread newThread(String name, Runnable runnable) {
-        return Thread.ofVirtual().name(name).unstarted(runnable);
+        if (config.isEnableVirtualThread()) {
+            return Thread.ofVirtual().name(name).unstarted(runnable);
+        } else {
+            return new Thread(runnable, name);
+        }
     }
 
     public ExtendedFancyLogger getFancyLogger() {

--- a/src/main/java/de/oliver/fancynpcs/FancyNpcsConfigImpl.java
+++ b/src/main/java/de/oliver/fancynpcs/FancyNpcsConfigImpl.java
@@ -74,6 +74,11 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
     private List<String> blockedCommands;
 
     /**
+     * Indicates whether Virtual Threads are enabled.
+     */
+    private boolean enableVirtualThread;
+
+    /**
      * The maximum number of NPCs per permission. (for the 'player-npcs' feature flag only)
      */
     private Map<String, Integer> maxNpcsPerPermission;
@@ -118,6 +123,8 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
         blockedCommands = (List<String>) ConfigHelper.getOrDefault(config, "blocked_commands", Arrays.asList("op", "ban"));
         config.setInlineComments("blocked_commands", List.of("The commands that are blocked for NPCs in the message."));
 
+        enableVirtualThread = (boolean) ConfigHelper.getOrDefault(config, "virtual_thread", false);
+        config.setInlineComments("virtual_thread", List.of("Whether the plugin should use Virtual Threads."));
 
         if (!config.isSet("max-npcs")) {
             List<Map<String, Integer>> entries = new ArrayList<>();
@@ -187,5 +194,9 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
 
     public Map<String, Integer> getMaxNpcsPerPermission() {
         return maxNpcsPerPermission;
+    }
+
+    public boolean isEnableVirtualThread() {
+        return enableVirtualThread;
     }
 }

--- a/src/main/java/de/oliver/fancynpcs/FancyNpcsConfigImpl.java
+++ b/src/main/java/de/oliver/fancynpcs/FancyNpcsConfigImpl.java
@@ -139,7 +139,7 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
         blockedCommands = (List<String>) ConfigHelper.getOrDefault(config, "blocked_commands", Arrays.asList("op", "ban"));
         config.setInlineComments("blocked_commands", List.of("The commands that are blocked for NPCs in the message."));
 
-        enableVirtualThread = (boolean) ConfigHelper.getOrDefault(config, "virtual_thread", false);
+        enableVirtualThread = (boolean) ConfigHelper.getOrDefault(config, "virtual_thread", true);
         config.setInlineComments("virtual_thread", List.of("Whether the plugin should use Virtual Threads."));
 
         if (!config.isSet("max-npcs")) {


### PR DESCRIPTION
As I mentioned in my report, virtual threads can completely freeze and cause the plugin to shut down. When this happens, we have to stop the server, which leads to a series of errors because the threads will still try to execute. The more actions are pending, the longer the shutdown process takes.

Maybe later this problem will no longer exist, but in Java 21, it is still present.