### PR TITLE
Configurable visibility tracker interval

### DIFF
--- a/api/src/main/java/de/oliver/fancynpcs/api/FancyNpcsConfig.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/FancyNpcsConfig.java
@@ -17,6 +17,8 @@ public interface FancyNpcsConfig {
 
     int getNpcUpdateInterval();
 
+    int getNpcUpdateVisibilityInterval();
+
     int getTurnToPlayerDistance();
 
     int getVisibilityDistance();

--- a/src/main/java/de/oliver/fancynpcs/FancyNpcs.java
+++ b/src/main/java/de/oliver/fancynpcs/FancyNpcs.java
@@ -268,7 +268,7 @@ public class FancyNpcs extends JavaPlugin implements FancyNpcsPlugin {
         visibilityTracker = new VisibilityTracker();
 
         npcThread.scheduleAtFixedRate(new TurnToPlayerTracker(), 0, 50, TimeUnit.MILLISECONDS);
-        npcThread.scheduleAtFixedRate(visibilityTracker, 0, 1, TimeUnit.SECONDS);
+        npcThread.scheduleAtFixedRate(visibilityTracker, 0, (config.getNpcUpdateVisibilityInterval() * 50L), TimeUnit.MILLISECONDS);
 
         int autosaveInterval = config.getAutoSaveInterval();
         if (config.isEnableAutoSave() && config.getAutoSaveInterval() > 0) {

--- a/src/main/java/de/oliver/fancynpcs/FancyNpcsConfigImpl.java
+++ b/src/main/java/de/oliver/fancynpcs/FancyNpcsConfigImpl.java
@@ -46,6 +46,11 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
     private int npcUpdateInterval;
 
     /**
+     * The interval at which NPC visibility is updated. In ticks.
+     */
+    private int npcUpdateVisibilityInterval;
+
+    /**
      * Indicates whether commands should be registered.
      * <p>
      * This is useful for users who want to use the plugin's API only.
@@ -102,6 +107,9 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
 
         npcUpdateInterval = (int) ConfigHelper.getOrDefault(config, "npc_update_interval", 30);
         config.setInlineComments("npc_update_skin_interval", List.of("The interval at which the NPC is updated (in minutes). Only if the skin or displayName is a placeholder."));
+
+        npcUpdateVisibilityInterval = (int) ConfigHelper.getOrDefault(config, "npc_update_visibility_interval", 20);
+        config.setInlineComments("npc_update_visibility_interval", List.of("The interval at which the NPC visibility is updated (in ticks)."));
 
         registerCommands = (boolean) ConfigHelper.getOrDefault(config, "register_commands", true);
         config.setInlineComments("register_commands", List.of("Whether the plugin should register its commands."));
@@ -163,6 +171,10 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
 
     public int getNpcUpdateInterval() {
         return npcUpdateInterval;
+    }
+
+    public int getNpcUpdateVisibilityInterval() {
+        return npcUpdateVisibilityInterval;
     }
 
     public boolean isRegisterCommands() {


### PR DESCRIPTION
Allows for customization of rate at which visibility of NPCs is being updated. Defaults to `20` ticks, which is exactly what it used to be prior these changes. Lowering the value could possibly make NPCs spawn earlier when entering their visibility range.