### PR TITLE
configurable turn_to_player direction reset

### DIFF
--- a/api/src/main/java/de/oliver/fancynpcs/api/FancyNpcsConfig.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/FancyNpcsConfig.java
@@ -19,6 +19,8 @@ public interface FancyNpcsConfig {
 
     int getTurnToPlayerDistance();
 
+    boolean isTurnToPlayerResetToInitialDirection();
+
     int getVisibilityDistance();
 
     int getRemoveNpcsFromPlayerlistDelay();

--- a/src/main/java/de/oliver/fancynpcs/FancyNpcsConfigImpl.java
+++ b/src/main/java/de/oliver/fancynpcs/FancyNpcsConfigImpl.java
@@ -58,6 +58,11 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
     private int turnToPlayerDistance;
 
     /**
+     * Indicates whether direction of NPC should be reset when leaving their range.
+     */
+    private boolean turnToPlayerResetToInitialDirection;
+
+    /**
      * The distance at which NPCs are visible.
      */
     private int visibilityDistance;
@@ -108,6 +113,9 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
 
         turnToPlayerDistance = (int) ConfigHelper.getOrDefault(config, "turn_to_player_distance", 5);
         config.setInlineComments("turn_to_player_distance", List.of("The distance at which NPCs turn to the player."));
+
+        turnToPlayerResetToInitialDirection = (boolean) ConfigHelper.getOrDefault(config, "turn_to_player_reset_to_initial_direction", false);
+        config.setInlineComments("turn_to_player_reset_to_initial_direction", List.of("Whether direction of NPC should be reset when leaving their turning range."));
 
         visibilityDistance = (int) ConfigHelper.getOrDefault(config, "visibility_distance", 20);
         config.setInlineComments("visibility_distance", List.of("The distance at which NPCs are visible."));
@@ -167,6 +175,10 @@ public class FancyNpcsConfigImpl implements FancyNpcsConfig {
 
     public boolean isRegisterCommands() {
         return registerCommands;
+    }
+
+    public boolean isTurnToPlayerResetToInitialDirection() {
+        return turnToPlayerResetToInitialDirection;
     }
 
     public int getTurnToPlayerDistance() {

--- a/src/main/java/de/oliver/fancynpcs/tracker/TurnToPlayerTracker.java
+++ b/src/main/java/de/oliver/fancynpcs/tracker/TurnToPlayerTracker.java
@@ -50,6 +50,10 @@ public class TurnToPlayerTracker implements Runnable {
                     // Updating state if changed.
                 } else if (npcData.isTurnToPlayer() && npc.getIsLookingAtPlayer().getOrDefault(player.getUniqueId(), false)) {
                     npc.getIsLookingAtPlayer().put(player.getUniqueId(), false);
+                    // Resetting to initial direction, if configured.
+                    if (FancyNpcs.getInstance().getFancyNpcConfig().isTurnToPlayerResetToInitialDirection()) {
+                        npc.move(player, false);
+                    }
                     // Calling NpcStopLookingEvent from the main thread.
                     FancyNpcs.getInstance().getScheduler().runTask(null, () -> {
                         Bukkit.getPluginManager().callEvent(new NpcStopLookingEvent(npc, player));


### PR DESCRIPTION
It moves the NPC without swinging their hand, so direction is not "fully" reset. Doing so otherwise would make it look weird.

Not sure 100% sure about field, method and configuration property names. They should be descriptive enough but I feel like they could be improved.

https://github.com/user-attachments/assets/e3f8f493-f205-4869-914c-b8326a040fb8



