### PR TITLE
do not attempt to load world on Folia servers

### DIFF
--- a/src/main/java/de/oliver/fancynpcs/NpcManagerImpl.java
+++ b/src/main/java/de/oliver/fancynpcs/NpcManagerImpl.java
@@ -1,6 +1,7 @@
 package de.oliver.fancynpcs;
 
 import de.oliver.fancyanalytics.logger.ExtendedFancyLogger;
+import de.oliver.fancylib.serverSoftware.ServerSoftware;
 import de.oliver.fancynpcs.api.*;
 import de.oliver.fancynpcs.api.actions.ActionTrigger;
 import de.oliver.fancynpcs.api.actions.NpcAction;
@@ -246,8 +247,7 @@ public class NpcManagerImpl implements NpcManager {
                 World world = Bukkit.getWorld(worldName);
 
                 if (world == null) {
-                    logger.info("Trying to load the world: '" + worldName + "'");
-                    world = new WorldCreator(worldName).createWorld();
+                    world = (!ServerSoftware.isFolia()) ? new WorldCreator(worldName).createWorld() : null;
                 }
 
                 if (world == null) {


### PR DESCRIPTION
This operation is unsupported on Folia. We should instead refuse to load NPCs in worlds that were not loaded by the server initially.

Fixes https://github.com/FancyMcPlugins/FancyNpcs/issues/211