### PR TITLE
Added issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,14 +11,6 @@ body:
       placeholder: Tell us what you see!
     validations:
       required: true
-  - type: input
-    id: version
-    attributes:
-      label: Version
-      description: What version of our software are you running?
-      placeholder: "1.4.1-rc.2"
-    validations:
-      required: true
   - type: dropdown
     id: software
     attributes:
@@ -28,6 +20,22 @@ body:
         - Paper
         - Folia
         - Other
+    validations:
+      required: true
+  - type: input
+    id: plugin_version
+    attributes:
+      label: Plugin version
+      description: Which version of Fancy npcs are you using?
+      placeholder: "1.4.1-rc.2"
+    validations:
+      required: true
+  - type: input
+    id: server_version
+    attributes:
+      label: Server version
+      description: What version is your minecraft server running on?
+      placeholder: "1.21.4"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: Bug Report
+description: File a bug report.
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      placeholder: "1.4.1-rc.2"
+    validations:
+      required: true
+  - type: dropdown
+    id: software
+    attributes:
+      label: In which software has the error occurred?
+      multiple: false
+      options:
+        - Paper
+        - Folia
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     id: plugin_version
     attributes:
       label: Plugin version
-      description: Which version of Fancy npcs are you using?
+      description: Which version of FancyNpcs are you using?
       placeholder: "1.4.1-rc.2"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,13 @@
+name: Feature Request
+description: Suggest a new Feature.
+title: "Feature: "
+labels: ["feature"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe your idea
+      description: Please provide a raw or complete concent of the feature
+      placeholder: A detailed description, possibly with examples or concept arts.
+    validations:
+      required: true


### PR DESCRIPTION
This pull request introduces new issue templates for bug reports and feature requests, and disables blank issues. The changes aim to streamline the issue reporting process by providing structured templates for users to fill out.

New issue templates:

* [`.github/ISSUE_TEMPLATE/bug_report.yml`](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efR1-R38): Added a new template for bug reports, including fields for describing what happened, the software version, the affected software, and relevant log output.
* [`.github/ISSUE_TEMPLATE/feature_request.yml`](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdR1-R13): Added a new template for feature requests, including a field for describing the feature idea.

Configuration changes:

* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2R1): Disabled the option to create blank issues.