### PR TITLE
Fix possible NullPointerException due to threading

### DIFF
--- a/api/src/main/java/de/oliver/fancynpcs/api/actions/executor/ActionExecutor.java
+++ b/api/src/main/java/de/oliver/fancynpcs/api/actions/executor/ActionExecutor.java
@@ -14,11 +14,9 @@ public class ActionExecutor {
 
     public static void execute(ActionTrigger trigger, Npc npc, Player player) {
         String key = getKey(trigger, npc, player);
-        if (runningContexts.containsKey(key)) {
-            ActionExecutionContext context = runningContexts.get(key);
-            if (context.shouldBlockUntilDone() && !context.isTerminated()) {
-                return;
-            }
+        ActionExecutionContext runningContext = runningContexts.get(key);
+        if (runningContext != null && runningContext.shouldBlockUntilDone() && !runningContext.isTerminated()) {
+            return;
         }
 
         ActionExecutionContext context = new ActionExecutionContext(trigger, npc, player.getUniqueId());


### PR DESCRIPTION
Due to threading it's possible to get this error in console when you spam interactions with an npc:
```
[14:13:29 ERROR]: Could not pass event PlayerUseUnknownEntityEvent to FancyNpcs v2.4.2
java.lang.NullPointerException: Cannot invoke "de.oliver.fancynpcs.api.actions.executor.ActionExecutionContext.shouldBlockUntilDone()" because "context" is null
        at FancyNpcs-2.4.2.jar/de.oliver.fancynpcs.api.actions.executor.ActionExecutor.execute(ActionExecutor.java:19) ~[FancyNpcs-2.4.2.jar:?]
        at FancyNpcs-2.4.2.jar/de.oliver.fancynpcs.api.Npc.interact(Npc.java:182) ~[FancyNpcs-2.4.2.jar:?]
        at FancyNpcs-2.4.2.jar/de.oliver.fancynpcs.listeners.PlayerUseUnknownEntityListener.onPlayerUseUnknownEntity(PlayerUseUnknownEntityListener.java:24) ~[FancyNpcs-2.4.2.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[purpur-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[purpur-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[purpur-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.event.Event.callEvent(Event.java:45) ~[purpur-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerUseUnknownEntityEvent(CraftEventFactory.java:2208) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.network.ServerGamePacketListenerImpl$4.onAttack(ServerGamePacketListenerImpl.java:2937) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.network.protocol.game.ServerboundInteractPacket$1.dispatch(ServerboundInteractPacket.java:29) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.network.protocol.game.ServerboundInteractPacket.dispatch(ServerboundInteractPacket.java:91) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleInteract(ServerGamePacketListenerImpl.java:2924) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.network.protocol.game.ServerboundInteractPacket.handle(ServerboundInteractPacket.java:78) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.network.protocol.game.ServerboundInteractPacket.handle(ServerboundInteractPacket.java:14) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:29) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:155) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1494) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:176) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:129) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1474) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1468) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:139) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:1425) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1433) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1310) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:313) ~[purpur-1.21.4.jar:1.21.4-2384-79c1192]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```